### PR TITLE
Fixed API for chain method result

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ import { Maybe } from 'monad-maniac'
 const just = Maybe.of(10)
 const divided = just.chain((x) => x / 2) // 5
 const none = just.chain((x) => x > 10000 ? x / 2 : undefined) // undefined
+const maybeDivided = just.chain((x) => Maybe.of(x > 10000 ? x / 2 : undefined)) // Nothing()
 ```
 
 #### filter

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -59,7 +59,7 @@ export interface Maybe<T> {
    * console.log(result) // undefined
    * ```
    */
-  chain<U>(f: (value: T) => U): U | undefined
+  chain<U>(f: (value: T) => U): U | Maybe<T>
 
   /** Return true if `Nothing` */
   isNothing(): boolean
@@ -386,14 +386,14 @@ export function caseOf<T, U>(matcher: CaseOf<T, U>, maybe?: Maybe<T>): U | ((may
  * const resultFoo = Maybe.chain(foo, (x) => x * x) // 144
  * ```
  * */
-export function chain<T, U>(f: (value: T) => U, maybe: Maybe<T>): U | undefined
+export function chain<T, U>(f: (value: T) => U, maybe: Maybe<T>): U | Maybe<T>
 /**
  * Just curried `chain`.
  *
  * _(a -> b) -> Maybe(a) -> b_
  */
-export function chain<T, U>(f: (value: T) => U): (maybe: Maybe<T>) => U | undefined
-export function chain<T, U>(f: (value: T) => U, maybe?: Maybe<T>): U | undefined | ((maybe: Maybe<T>) => U | undefined) {
+export function chain<T, U>(f: (value: T) => U): (maybe: Maybe<T>) => U | Maybe<T>
+export function chain<T, U>(f: (value: T) => U, maybe?: Maybe<T>): U | Maybe<T> | ((maybe: Maybe<T>) => U | Maybe<T>) {
   const op = (m: Maybe<T>) => m.chain(f)
   return helpers.curry1(op, maybe)
 }
@@ -590,8 +590,8 @@ export class Nothing<T> implements Maybe<T> {
   }
 
   /** Method implements from [`Maybe.chain`](../interfaces/_maybe_.maybeshape.html#chain) */
-  chain<U>(_f: (value: T) => U): undefined {
-    return undefined
+  chain<U>(_f: (value: T) => U): Maybe<T> {
+    return this
   }
 
   filter(_f: (value: T) => boolean): Maybe<T> {

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -56,7 +56,7 @@ export interface Maybe<T> {
    *  .filter((x) => x > 1000) // Nothing() - next function will be called never
    *  .map((x) => x + 10) // 60
    *  .chain((x) => x / 3) // 20 - actually the function will not be called
-   * console.log(result) // undefined
+   * console.log(result) // Nothing()
    * ```
    */
   chain<U>(f: (value: T) => U): U | Maybe<T>

--- a/tests/maybe.test.ts
+++ b/tests/maybe.test.ts
@@ -66,9 +66,11 @@ describe('Pure functions', () => {
       const just = Maybe.of(234)
       const nothing = Maybe.of(null)
       const nothing2 = Maybe.of(undefined)
+      const chained1 = Maybe.chain(double, nothing)
+      const chained2 = Maybe.chain(double, nothing2)
       expect(Maybe.chain(toNothing, just)).toBeUndefined()
-      expect(Maybe.chain(double, nothing)).toBeUndefined()
-      expect(Maybe.chain(double, nothing2)).toBeUndefined()
+      expect(chained1  instanceof Maybe.Nothing).toBe(true)
+      expect(chained2  instanceof Maybe.Nothing).toBe(true)
     })
 
     it('carry', () => {
@@ -300,21 +302,21 @@ describe('Just and Nothing', () => {
     expect(just.toString()).toBe('Just(5)')
     expect(just.chain(double)).toBe(10)
     expect(just.map(double).chain(double)).toBe(20)
-    expect(just.map(double).map(double).chain(toNothing)).toBeUndefined()
+    expect(just.map(double).map(double).map(toNothing).chain(double) instanceof Maybe.Nothing).toBe(true)
     expect(
       just
         .map(double)
         .map(double)
         .map(toNothing)
-        .chain(double)
-    ).toBeUndefined()
+        .chain(double) instanceof Maybe.Nothing
+    ).toBe(true)
     expect(
       just
         .map(double)
         .map(double)
         .map(toNull)
-        .chain(double)
-    ).toBeUndefined()
+        .chain(double) instanceof Maybe.Nothing
+    ).toBe(true)
   })
 
   it('getOrElse', () => {


### PR DESCRIPTION
Now will not return `undefined` for `Nothing`. This method will returns `Nothing` if `chain` was called on `Nothing`.