### PR TITLE
New version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed mistake in naming `mather` to `matcher` :sweat_smile:
 - Fixed type `ApplicativeResult` (it could not return the nullable, now this will be available)
 - :fire: **WARNING** `MaybeShape` marked as **Deprecated**!
+- :fire: `Maybe.chain` was fixed, now will returns `Nothing` if the method was called on `Nothing`!
 
 ## :bulb: [0.1.0] - 2019-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Smoke test and really build to **Travis CI**.
 - Labels of `npm`, `coverage`, `travis`.
 
-[unreleased]: https://github.com/snatvb/monad-maniac/compare/v0.1.0...develop
+[unreleased]: https://github.com/snatvb/monad-maniac/compare/v0.2.0...develop
 [0.1.0]: https://github.com/snatvb/monad-maniac/compare/v0.0.1...v0.1.0
 [0.2.0]: https://github.com/snatvb/monad-maniac/compare/v0.1.0...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2019-TO-BE
+
+### Added
+- `lift` as pure function
+
+### Changed
+- Fixed mistake in naming `mather` to `matcher` :sweat_smile:
+- Fixed type `ApplicativeResult` (could not return nullable)
+
 ## [0.1.0] - 2019-05-19
 
 ### Added
@@ -20,3 +29,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [unreleased]: https://github.com/snatvb/monad-maniac/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/snatvb/monad-maniac/compare/v0.0.1...v0.1.0
+[0.2.0]: https://github.com/snatvb/monad-maniac/compare/v0.1.0...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,28 @@
-# Changelog
+# :page_with_curl: Changelog
 
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased] :bomb:
 
-## [0.2.0] - 2019-05-21
+## :bulb: [0.2.0] - 2019-05-21
 
-### Added
+### :gift: Added
 - `lift` as pure function for `Maybe`
 - `Either` monad
 - `Maybe` type for ts-doc annotation :tada:
 - Alias for `Maybe` interface for use as type - `Shape`, this need using with context `Maybe.Shape<T>`
 
-### Changed
+### :surfer: Changed
 - Fixed mistake in naming `mather` to `matcher` :sweat_smile:
 - Fixed type `ApplicativeResult` (it could not return the nullable, now this will be available)
-- **WARNING** `MaybeShape` marked as **Deprecated**!
+- :fire: **WARNING** `MaybeShape` marked as **Deprecated**!
 
-## [0.1.0] - 2019-05-19
+## :bulb: [0.1.0] - 2019-05-19
 
-### Added
+### :gift: Added
 - `join` as method and pure function.
 - `chain` as method and pure function.
 - `equals` as method and pure function.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0] - 2019-TO-BE
+## [0.2.0] - 2019-05-21
 
 ### Added
-- `lift` as pure function
+- `lift` as pure function for `Maybe`
+- `Either` monad
+- `Maybe` type for ts-doc annotation :tada:
+- Alias for `Maybe` interface for use as type - `Shape`, this need using with context `Maybe.Shape<T>`
 
 ### Changed
 - Fixed mistake in naming `mather` to `matcher` :sweat_smile:
-- Fixed type `ApplicativeResult` (could not return nullable)
+- Fixed type `ApplicativeResult` (it could not return the nullable, now this will be available)
+- **WARNING** `MaybeShape` marked as **Deprecated**!
 
 ## [0.1.0] - 2019-05-19
 
@@ -27,6 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Smoke test and really build to **Travis CI**.
 - Labels of `npm`, `coverage`, `travis`.
 
-[unreleased]: https://github.com/snatvb/monad-maniac/compare/v0.1.0...HEAD
+[unreleased]: https://github.com/snatvb/monad-maniac/compare/v0.1.0...develop
 [0.1.0]: https://github.com/snatvb/monad-maniac/compare/v0.0.1...v0.1.0
 [0.2.0]: https://github.com/snatvb/monad-maniac/compare/v0.1.0...v0.2.0

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 ## URLs
 - [Documentation](http://mm.snatvb.ru)
+  * [Maybe](http://mm.snatvb.ru/modules/_maybe_.html)
+  * [Either](http://mm.snatvb.ru/modules/_either_.html)
 - [Github](https://github.com/snatvb/monad-maniac)
 - [NPM](https://www.npmjs.com/package/monad-maniac)
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ import { Maybe } from 'monad-maniac'
 const just = Maybe.of(10)
 const divided = just.chain((x) => x / 2) // 5
 const none = just.chain((x) => x > 10000 ? x / 2 : undefined) // undefined
+const maybeDivided = just.chain((x) => Maybe.of(x > 10000 ? x / 2 : undefined)) // Nothing()
 ```
 
 #### filter

--- a/scripts/build-docs
+++ b/scripts/build-docs
@@ -1,11 +1,9 @@
 #!/usr/bin/env sh
 rm -rf docs && \
   ./node_modules/.bin/typedoc \
-    --out docs \
+    --options scripts/typedoc.js \
     --includes src \
-    --exclude src/helpers.ts \
     --tsconfig ts/doc.tsconfig.json \
-    --theme minimal \
     src && \
   touch docs/.nojekyll && \
 echo "snatvb.ru" > docs/CNAME

--- a/scripts/typedoc.js
+++ b/scripts/typedoc.js
@@ -1,0 +1,9 @@
+module.exports = {
+  out: 'docs',
+  includes: 'src',
+  includes: 'src',
+  exclude: [
+    'src/helpers.ts',
+    'src/types.ts',
+  ],
+}

--- a/smoke-test.js
+++ b/smoke-test.js
@@ -29,7 +29,7 @@ if (nothing.map(double).toString() !== 'Nothing()') {
 if (Either.left('Some error').toString() !== 'Left(Some error)') {
   throw new Error('Not Left(Some error)')
 }
-if (Either.right('Some value').toString() !== 'Left(Some value)') {
+if (Either.right('Some value').toString() !== 'Right(Some value)') {
   throw new Error('Not Right(Some value)')
 }
 `

--- a/smoke-test.js
+++ b/smoke-test.js
@@ -12,17 +12,25 @@ const writeFile = promisify(fs.writeFile);
 const assert = require('assert');
 
 const code = `
-const { Maybe } = require('monad-maniac')
+const { Maybe, Either } = require('monad-maniac')
 
 const double = (x) => x * 2
 const just = Maybe.of(10)
 const nothing = Maybe.of(null)
+console.log(Either)
 
 if (just.map(double).toString() !== 'Just(20)') {
   throw new Error('Not Just(20)')
 }
 if (nothing.map(double).toString() !== 'Nothing()') {
   throw new Error('Not Nothing()')
+}
+
+if (Either.left('Some error').toString() !== 'Left(Some error)') {
+  throw new Error('Not Left(Some error)')
+}
+if (Either.right('Some value').toString() !== 'Left(Some value)') {
+  throw new Error('Not Right(Some value)')
 }
 `
 

--- a/src/either.ts
+++ b/src/either.ts
@@ -79,6 +79,18 @@ export function chain<L, R, U>(f: (value: R) => U, either?: Either<L, R>): L | U
   return helpers.curry1(op, either)
 }
 
+export function orElse<L, R, U>(f: (value: L) => U, either: Either<L, R>): L | U
+/**
+ * Just curried `orElse`.
+ *
+ * _(a -> b) -> Either(a) -> Either(b)_
+ */
+export function orElse<L, R, U>(f: (value: L) => U): (either: Either<L, R>) => R | U
+export function orElse<L, R, U>(f: (value: L) => U, either?: Either<L, R>): R | U | ((either: Either<L, R>) => R | U) {
+  const op = (either: Either<L, R>) => either.orElse(f)
+  return helpers.curry1(op, either)
+}
+
 export class Right<L ,R> implements Either<L ,R> {
   private value: R
 

--- a/src/either.ts
+++ b/src/either.ts
@@ -437,8 +437,8 @@ export function chain<L, R, U>(f: (value: R) => U, either?: Either<L, R>): Eithe
  *
  * const orElse = (message: string) => ({ message })
  *
- * left.orElse(orElse) // { message: 'Server error' }
- * right.orElse(orElse) // 150
+ * Either.orElse(orElse, left) // { message: 'Server error' }
+ * Either.orElse(orElse, right) // 150
  * ```
  */
 export function orElse<L, R, U>(f: (value: L) => U, either: Either<L, R>): R | U
@@ -461,8 +461,8 @@ export function orElse<L, R, U>(f: (value: L) => U, either?: Either<L, R>): R | 
  * import { Either } from 'monad-maniac'
  * const right: Either.Shape<number, number> = new Either.Right(150)
  *
- * right.filter((x) => x > 150) // Left(150)
- * right.filter((x) => x < 300) // Right(150)
+ * Either.filter((x) => x > 150, right) // Left(150)
+ * Either.filter((x) => x < 300, right) // Right(150)
  * ```
  */
 export function filter<L, R>(predicate: (value: R) => boolean, either: Either<L, R>): Either<L | R, R >
@@ -484,8 +484,8 @@ export function filter<L, R>(predicate: (value: R) => boolean, either?: Either<L
  * const left = Either.left<number, number>(150)
  * const right = Either.right<number, number>(150)
  *
- * const resultLeft = left.getOrElse(0) // 0
- * const resultRight = right.getOrElse(0) // 150
+ * const resultLeft = Either.getOrElse(0, left) // 0
+ * const resultRight = Either.getOrElse(0, right) // 150
  * ```
  */
 export function getOrElse<L, R, U>(defaultValue: U, either: Either<L, R>): R | U
@@ -498,6 +498,24 @@ export function getOrElse<L, R, U>(defaultValue: U, either?: Either<L, R>): R | 
   return helpers.curry1(op, either)
 }
 
+/**
+ * Method like [`Either.caseOf`](../interfaces/_either_.shape.html#caseof)
+ *
+ * ```ts
+ * import { Either } from 'monad-maniac'
+ *
+ * const matcher: Either.CaseOf<string, number, number> = {
+ *   Right: (x) => x * 2,
+ *   Left: (message) => message.length,
+ * }
+ *
+ * const left: Either.Shape<string, number> = new Either.Left('Server error')
+ * const right: Either.Shape<string, number> = new Either.Right(150)
+ *
+ * Either.caseOf(matcher, left) // 12
+ * Either.caseOf(matcher, right) // 300
+ * ```
+ */
 export function caseOf<L, R, U>(matcher: CaseOf<L, R, U>, either: Either<L, R>): U
 /**
  * Just curried `caseOf`.

--- a/src/either.ts
+++ b/src/either.ts
@@ -58,8 +58,6 @@ export function fromNullable<L, R>(value: R | L): Either<L, R> {
 export function map<L, R, U>(f: (value: R) => U, either: Either<L, R>): Either<L, U>
 /**
  * Just curried `map`.
- *
- * _(a -> b) -> Either(a) -> Either(b)_
  */
 export function map<L, R, U>(f: (value: R) => U): (either: Either<L, R>) => Either<L, U>
 export function map<L, R, U>(f: (value: R) => U, either?: Either<L, R>): Either<L, U> | ((either: Either<L, R>) => Either<L, U>) {
@@ -70,8 +68,6 @@ export function map<L, R, U>(f: (value: R) => U, either?: Either<L, R>): Either<
 export function chain<L, R, U>(f: (value: R) => U, either: Either<L, R>): L | U
 /**
  * Just curried `chain`.
- *
- * _(a -> b) -> Either(a) -> Either(b)_
  */
 export function chain<L, R, U>(f: (value: R) => U): (either: Either<L, R>) => L | U
 export function chain<L, R, U>(f: (value: R) => U, either?: Either<L, R>): L | U | ((either: Either<L, R>) => L | U) {
@@ -82,8 +78,6 @@ export function chain<L, R, U>(f: (value: R) => U, either?: Either<L, R>): L | U
 export function orElse<L, R, U>(f: (value: L) => U, either: Either<L, R>): R | U
 /**
  * Just curried `orElse`.
- *
- * _(a -> b) -> Either(a) -> Either(b)_
  */
 export function orElse<L, R, U>(f: (value: L) => U): (either: Either<L, R>) => R | U
 export function orElse<L, R, U>(f: (value: L) => U, either?: Either<L, R>): R | U | ((either: Either<L, R>) => R | U) {
@@ -94,12 +88,20 @@ export function orElse<L, R, U>(f: (value: L) => U, either?: Either<L, R>): R | 
 export function filter<L, R>(predicate: (value: R) => boolean, either: Either<L, R>): Either<L | R, R >
 /**
  * Just curried `filter`.
- *
- * _(a -> b) -> Either(a) -> Either(b)_
  */
 export function filter<L, R>(predicate: (value: R) => boolean): (either: Either<L, R>) => Either<L | R, R >
 export function filter<L, R>(predicate: (value: R) => boolean, either?: Either<L, R>): Either<L | R, R > | ((either: Either<L, R>) => Either<L | R, R >) {
   const op = (either: Either<L, R>) => either.filter(predicate)
+  return helpers.curry1(op, either)
+}
+
+export function getOrElse<L, R, U>(defaultValue: U, either: Either<L, R>): R | U
+/**
+ * Just curried `getOrElse`.
+ */
+export function getOrElse<L, R, U>(defaultValue: U): (either: Either<L, R>) => R | U
+export function getOrElse<L, R, U>(defaultValue: U, either?: Either<L, R>): R | U | ((either: Either<L, R>) => R | U) {
+  const op = (either: Either<L, R>) => either.getOrElse(defaultValue)
   return helpers.curry1(op, either)
 }
 

--- a/src/either.ts
+++ b/src/either.ts
@@ -62,9 +62,9 @@ export function attempt<R>(f: (...args: any[]) => R, args?: any[]): Either<Error
   return helpers.curry1(op, args)
 }
 
-export function asyncAttempt<R>(f: (...args: any[]) => R, args: any[]): Promise<Either<Error, R>>
-export function asyncAttempt<R>(f: (...args: any[]) => R): (args: any[]) => Promise<Either<Error, R>>
-export function asyncAttempt<R>(f: (...args: any[]) => R, args?: any[]): Promise<Either<Error, R>> | ((args: any[]) => Promise<Either<Error, R>>) {
+export function asyncAttempt<R>(f: (...args: any[]) => Promise<R>, args: any[]): Promise<Either<Error, R>>
+export function asyncAttempt<R>(f: (...args: any[]) => Promise<R>): (args: any[]) => Promise<Either<Error, R>>
+export function asyncAttempt<R>(f: (...args: any[]) => Promise<R>, args?: any[]): Promise<Either<Error, R>> | ((args: any[]) => Promise<Either<Error, R>>) {
   const op = async (args: any[]) => {
     try {
       return new Right<Error, R>(await f(...args))

--- a/src/either.ts
+++ b/src/either.ts
@@ -8,6 +8,7 @@ export type CaseOf<L, R, U> = {
 
 export interface Shape<L, R> {
   map<U>(f: (value: R) => U): Shape<L, U>
+  orElse<U>(f: (value: L) => U): U | R
   chain<U>(f: (value: R) => U): U | L
   filter(predicate: (value: R) => boolean): Shape<L | R, R >
   getOrElse<U>(defaultValue: U): R | U
@@ -40,6 +41,10 @@ export class Right<L ,R> implements Shape<L ,R> {
     return of(f(this.value))
   }
 
+  orElse<U>(_f: (value: L) => U): U | R {
+    return this.value
+  }
+
   chain<U>(f: (value: R) => U): U | L {
     return f(this.value)
   }
@@ -50,7 +55,7 @@ export class Right<L ,R> implements Shape<L ,R> {
     }
     return new Left<R, R>(this.value)
   }
-  getOrElse<U>(_defaultValue: U): R | U {
+  getOrElse<U>(_defaultValue: U): R {
     return this.value
   }
   get(): L | R {
@@ -79,6 +84,10 @@ class Left<L, R> implements  Shape<L, R> {
 
   map<U>(_f: (value: R) => U): Shape<L, U> {
     return new Left<L, U>(this.value)
+  }
+
+  orElse<U>(f: (value: L) => U): U {
+    return f(this.value)
   }
 
   chain<U>(_f: (value: R) => U): U | L {

--- a/src/either.ts
+++ b/src/either.ts
@@ -402,6 +402,19 @@ export function map<L, R, U>(f: (value: R) => U, either?: Either<L, R>): Either<
   return helpers.curry1(op, either)
 }
 
+/**
+ * Method like [`Either.chain`](../interfaces/_either_.shape.html#chain)
+ *
+ * ```ts
+ * import { Either } from 'monad-maniac'
+ *
+ * const name: string | void = Math.random() > 0.5 ? 'Jake' : undefined
+ * const result: Either.Shape<string, string> = typeof name === 'string'
+ *  ? new Either.Right(name)
+ *  : new Either.Left('Server error')
+ * const greeting = Either.chain((name) => `Welcome, ${name}!`, result) // 'Welcome, Jake' or 'Server error'
+ * ```
+ * */
 export function chain<L, R, U>(f: (value: R) => U, either: Either<L, R>): Either<L, U> | U
 /**
  * Just curried `chain`.
@@ -412,6 +425,22 @@ export function chain<L, R, U>(f: (value: R) => U, either?: Either<L, R>): Eithe
   return helpers.curry1(op, either)
 }
 
+/**
+ * Method like [`Either.orElse`](../interfaces/_either_.shape.html#orElse)
+ *
+ * Apple some function to `Left` value.
+ *
+ * ```ts
+ * import { Either } from 'monad-maniac'
+ * const left: Either.Shape<string, number> = new Either.Left('Server error')
+ * const right: Either.Shape<string, number> = new Either.Right(150)
+ *
+ * const orElse = (message: string) => ({ message })
+ *
+ * left.orElse(orElse) // { message: 'Server error' }
+ * right.orElse(orElse) // 150
+ * ```
+ */
 export function orElse<L, R, U>(f: (value: L) => U, either: Either<L, R>): R | U
 /**
  * Just curried `orElse`.

--- a/src/either.ts
+++ b/src/either.ts
@@ -334,6 +334,29 @@ export function attempt<R>(f: (...args: any[]) => R, args?: any[]): Either<Error
   return helpers.curry1(op, args)
 }
 
+/**
+ * Function like [`Either.attempt`](../modules/_either_.maybeshape.html#attempt)
+ * This is async`try {} catch(error) {}` for `Either`.
+ * If the function throws exception then the error will
+ * catch and placed in `Left`, and in `Right` otherwise.
+ *
+ * ```ts
+ * import { Either } from 'monad-maniac'
+ *
+ * const errorAsyncFunction = (x: number): Promise<number> => new Promise((resolve, reject) => {
+ *   if (x === 0) {
+ *     reject(new Error('Number is zero!'))
+ *   }
+ *   resolve(x)
+ * })
+ *
+ * const left = await Either.asyncAttempt(errorAsyncFunction, [0])
+ * const right = await Either.asyncAttempt(errorAsyncFunction, [10])
+ * left.map(double).toString() // Left(Error: Number is zero!)
+ * right.map(double).toString() // Right(20)
+ *
+ * ```
+ */
 export function asyncAttempt<R>(f: (...args: any[]) => Promise<R>, args: any[]): Promise<Either<Error, R>>
 export function asyncAttempt<R>(f: (...args: any[]) => Promise<R>): (args: any[]) => Promise<Either<Error, R>>
 export function asyncAttempt<R>(f: (...args: any[]) => Promise<R>, args?: any[]): Promise<Either<Error, R>> | ((args: any[]) => Promise<Either<Error, R>>) {

--- a/src/either.ts
+++ b/src/either.ts
@@ -26,6 +26,14 @@ export function of<L, R>(value: R): Either<L, R> {
   return new Right(value)
 }
 
+export function left<L, R>(value: L): Either<L, R> {
+  return new Left(value)
+}
+
+export function right<L, R>(value: R): Either<L, R> {
+  return new Right(value)
+}
+
 export function toString<L, R>(either: Either<L, R>): string {
   return either.toString()
 }

--- a/src/either.ts
+++ b/src/either.ts
@@ -49,6 +49,19 @@ export function fromNullable<L, R>(value: Nullable<R | L>): Either<Nullable<L>, 
   return new Right<L, R>(value as R)
 }
 
+export function attempt<R>(f: (...args: any[]) => R, args: any[]): Either<Error, R>
+export function attempt<R>(f: (...args: any[]) => R): (args: any[]) => Either<Error, R>
+export function attempt<R>(f: (...args: any[]) => R, args?: any[]): Either<Error, R> | ((args: any[]) => Either<Error, R>) {
+  const op = (args: any[]) => {
+    try {
+      return new Right<Error, R>(f(...args))
+    } catch(error) {
+      return new Left<Error, R>(error)
+    }
+  }
+  return helpers.curry1(op, args)
+}
+
 /**
  * Method like [`Either.map`](../interfaces/_either_.shape.html#map)
  *

--- a/src/either.ts
+++ b/src/either.ts
@@ -166,10 +166,10 @@ export class Right<L ,R> implements Either<L ,R> {
     return `Right(${String(this.value)})`
   }
   isLeft(): boolean {
-    return true
+    return false
   }
   isRight(): boolean {
-    return false
+    return true
   }
   caseOf<U>(matcher: CaseOf<L, R, U>): U {
     return matcher.Right(this.value)

--- a/src/either.ts
+++ b/src/either.ts
@@ -267,10 +267,33 @@ export function isRight<L, R>(either: Either<L, R>): boolean {
   return either.isRight()
 }
 
+/**
+ * Returns `value` from `Left` or `Right`
+ *
+ * ```ts
+ * import { Either } from 'monad-maniac'
+ *
+ * const right = Either.right<string, number>(10)
+ * const left = Either.left<string, number>('Some error')
+ *
+ * Either.get(left) // 'Some error'
+ * Either.get(right) // 10
+ * ```
+ */
 export function get<L, R>(either: Either<L, R>): L | R {
   return either.get()
 }
 
+/**
+ * Returns `value` from `Left` or `Right`
+ *
+ * ```ts
+ * import { Either } from 'monad-maniac'
+ *
+ * Either.fromNullable<string, number>(150).toString() // Right(150)
+ * Either.fromNullable<string, number>(null).toString() // Left(null)
+ * ```
+ */
 export function fromNullable<L, R>(value: Nullable<R | L>): Either<Nullable<L>, R> {
   if (value === null || value === undefined) {
     return new Left<Nullable<L>, R>(value as Nullable<L>)

--- a/src/either.ts
+++ b/src/either.ts
@@ -79,7 +79,7 @@ export function chain<L, R, U>(f: (value: R) => U, either?: Either<L, R>): L | U
   return helpers.curry1(op, either)
 }
 
-export function orElse<L, R, U>(f: (value: L) => U, either: Either<L, R>): L | U
+export function orElse<L, R, U>(f: (value: L) => U, either: Either<L, R>): R | U
 /**
  * Just curried `orElse`.
  *
@@ -88,6 +88,18 @@ export function orElse<L, R, U>(f: (value: L) => U, either: Either<L, R>): L | U
 export function orElse<L, R, U>(f: (value: L) => U): (either: Either<L, R>) => R | U
 export function orElse<L, R, U>(f: (value: L) => U, either?: Either<L, R>): R | U | ((either: Either<L, R>) => R | U) {
   const op = (either: Either<L, R>) => either.orElse(f)
+  return helpers.curry1(op, either)
+}
+
+export function filter<L, R, U>(predicate: (value: R) => boolean, either: Either<L, R>): Either<L | R, R >
+/**
+ * Just curried `filter`.
+ *
+ * _(a -> b) -> Either(a) -> Either(b)_
+ */
+export function filter<L, R, U>(predicate: (value: R) => boolean): (either: Either<L, R>) => Either<L | R, R >
+export function filter<L, R, U>(predicate: (value: R) => boolean, either?: Either<L, R>): Either<L | R, R > | ((either: Either<L, R>) => Either<L | R, R >) {
+  const op = (either: Either<L, R>) => either.filter(predicate)
   return helpers.curry1(op, either)
 }
 

--- a/src/either.ts
+++ b/src/either.ts
@@ -122,6 +122,19 @@ export interface Either<L, R> {
    * ```
    */
   get(): L | R
+  /**
+   * Returns `Left` or `Right` as `string`: `Left(left value)` or `Right(right value)`.
+   *
+   * ```ts
+   * import { Either } from 'monad-maniac'
+   *
+   * const left = Either.left<number, number>(300)
+   * const right = Either.right<number, number>(150)
+   *
+   * const resultLeft = left.toString() // Left(300)
+   * const resultRight = right.toString() // Right(150)
+   * ```
+   */
   toString(): string
   isLeft(): boolean
   isRight(): boolean

--- a/src/either.ts
+++ b/src/either.ts
@@ -38,6 +38,10 @@ export function isRight<L, R>(either: Either<L, R>): boolean {
   return either.isRight()
 }
 
+export function get<L, R>(either: Either<L, R>): L | R {
+  return either.get()
+}
+
 export function fromNullable<L, R>(value: R | L): Either<L, R> {
   if (value === null || value === undefined) {
     return new Left<L, R>(value as L)

--- a/src/either.ts
+++ b/src/either.ts
@@ -1,6 +1,7 @@
 import * as helpers from './helpers'
 import { Nullable } from './types'
 
+/** Mather type for caseOf */
 export type CaseOf<L, R, U> = {
   Right: (value: R) => U,
   Left: (value: L) => U,

--- a/src/either.ts
+++ b/src/either.ts
@@ -15,6 +15,14 @@ export interface Either<L, R> {
    * will call the function with value, for `Left` return `Left`.
    * If `map` will return `null` or `undefined` then return `Right` with that.
    * Be careful.
+   * @param f Function to apply for Right value
+   */
+  map<U>(f: (value: R) => U): Either<L, U>
+  orElse<U>(f: (value: L) => U): U | R
+  /**
+   * Apply some function to value in container. `map` for `Right`
+   * will call the function with value, for `Left` return `Left`
+   * else value what be returned from the function.
    * ```ts
    * import { Either } from 'monad-maniac'
    *
@@ -32,15 +40,14 @@ export interface Either<L, R> {
     *  return Either.right(multiplicand * factor)
    * }
    *
-   * const resultNormal = divide(10)(2).chain(nonZeroMultiply(20)).get() // 4
+   * const resultNormal = divide(10)(2).chain(nonZeroMultiply(20)).get() // 100
    * const resultErrorDivide = divide(10)(0).chain(nonZeroMultiply(20)).get() // 'Divider is zero!'
-   * const resultErrorMultiply= divide(0)(2).chain(nonZeroMultiply(20)).get() // ''Factor is zero!'
+   * const resultErrorMultiply= divide(0)(2).chain(nonZeroMultiply(20)).get() // 'Factor is zero!'
+   * const resultError = divide(0)(0).chain(nonZeroMultiply(20)).get() // 'Divider is zero!'
    *
    * ```
    * @param f Function to apply for Right value
    */
-  map<U>(f: (value: R) => U): Either<L, U>
-  orElse<U>(f: (value: L) => U): U | R
   chain<U>(f: (value: R) => U): U | Either<L, U>
   filter(predicate: (value: R) => boolean): Either<L | R, R >
   getOrElse<U>(defaultValue: U): R | U

--- a/src/either.ts
+++ b/src/either.ts
@@ -62,6 +62,19 @@ export function attempt<R>(f: (...args: any[]) => R, args?: any[]): Either<Error
   return helpers.curry1(op, args)
 }
 
+export function asyncAttempt<R>(f: (...args: any[]) => R, args: any[]): Promise<Either<Error, R>>
+export function asyncAttempt<R>(f: (...args: any[]) => R): (args: any[]) => Promise<Either<Error, R>>
+export function asyncAttempt<R>(f: (...args: any[]) => R, args?: any[]): Promise<Either<Error, R>> | ((args: any[]) => Promise<Either<Error, R>>) {
+  const op = async (args: any[]) => {
+    try {
+      return new Right<Error, R>(await f(...args))
+    } catch(error) {
+      return new Left<Error, R>(error)
+    }
+  }
+  return helpers.curry1(op, args)
+}
+
 /**
  * Method like [`Either.map`](../interfaces/_either_.shape.html#map)
  *

--- a/src/either.ts
+++ b/src/either.ts
@@ -1,9 +1,9 @@
 // import * as helpers from './helpers'
 // import { Nullable } from './types'
 
-export type CaseOf<L, R> = {
-  Right: (value: R) => L,
-  Left: () => L,
+export type CaseOf<L, R, U> = {
+  Right: (value: R) => U,
+  Left: (value: L) => U,
 }
 
 export interface Shape<L, R> {
@@ -15,7 +15,7 @@ export interface Shape<L, R> {
   toString(): string
   isLeft(): boolean
   isRight(): boolean
-  caseOf<U>(matcher: CaseOf<R, U>): U
+  caseOf<U>(matcher: CaseOf<L, R, U>): U
 }
 
 export function of<L, R>(value: R): Shape<L, R> {
@@ -57,16 +57,16 @@ export class Right<L ,R> implements Shape<L ,R> {
     return this.value
   }
   toString(): string {
-    throw new Error("Method not implemented.");
+    return `Right(${String(this.value)})`
   }
   isLeft(): boolean {
-    throw new Error("Method not implemented.");
+    return true
   }
   isRight(): boolean {
-    throw new Error("Method not implemented.");
+    return false
   }
-  caseOf<U>(matcher: CaseOf<R, U>): U {
-    throw new Error("Method not implemented.");
+  caseOf<U>(matcher: CaseOf<L, R, U>): U {
+    return matcher.Right(this.value)
   }
 }
 
@@ -95,15 +95,15 @@ class Left<L, R> implements  Shape<L, R> {
     return this.value
   }
   toString(): string {
-    throw new Error("Method not implemented.");
+    return `Left(${String(this.value)})`
   }
   isLeft(): boolean {
-    throw new Error("Method not implemented.");
+    return true
   }
   isRight(): boolean {
-    throw new Error("Method not implemented.");
+    return false
   }
-  caseOf<U>(matcher: CaseOf<R, U>): U {
-    throw new Error("Method not implemented.");
+  caseOf<U>(matcher: CaseOf<L, R, U>): U {
+    return matcher.Left(this.value)
   }
 }

--- a/src/either.ts
+++ b/src/either.ts
@@ -301,6 +301,26 @@ export function fromNullable<L, R>(value: Nullable<R | L>): Either<Nullable<L>, 
   return new Right<L, R>(value as R)
 }
 
+/**
+ * This is `try {} catch(error) {}` for `Either`.
+ * If the function throws exception then the error will
+ * catch and placed in `Left`, and in `Right` otherwise.
+ *
+ * ```ts
+ * import { Either } from 'monad-maniac'
+ *
+ * const errorFunction = (x: number): number => {
+ *   if (x === 0) {
+ *     throw new Error('Number is zero!')
+ *   }
+ *   return x
+ * }
+ *
+ * Either.attempt(errorFunction, [0]).map(double).toString() // Left(Error: Number is zero!)
+ * Either.attempt(errorFunction, [10]).map(double).toString() // Right(20)
+ *
+ * ```
+ */
 export function attempt<R>(f: (...args: any[]) => R, args: any[]): Either<Error, R>
 export function attempt<R>(f: (...args: any[]) => R): (args: any[]) => Either<Error, R>
 export function attempt<R>(f: (...args: any[]) => R, args?: any[]): Either<Error, R> | ((args: any[]) => Either<Error, R>) {

--- a/src/either.ts
+++ b/src/either.ts
@@ -42,7 +42,7 @@ export function fromNullable<L, R>(value: R | L): Either<L, R> {
  * const name: string | void = Math.random() > 0.5 ? 'Jake' : undefined
  * const result: Either.Shape<string, string> = typeof name === 'string'
  *  ? new Either.Right(name)
- * : new Either.Left('Server error')
+ *  : new Either.Left('Server error')
  * const greeting = Either.map((name) => `Welcome, ${name}!`, result)
  *
  * // ...
@@ -64,6 +64,18 @@ export function map<L, R, U>(f: (value: R) => U, either: Either<L, R>): Either<L
 export function map<L, R, U>(f: (value: R) => U): (either: Either<L, R>) => Either<L, U>
 export function map<L, R, U>(f: (value: R) => U, either?: Either<L, R>): Either<L, U> | ((either: Either<L, R>) => Either<L, U>) {
   const op = (either: Either<L, R>) => either.map(f)
+  return helpers.curry1(op, either)
+}
+
+export function chain<L, R, U>(f: (value: R) => U, either: Either<L, R>): L | U
+/**
+ * Just curried `chain`.
+ *
+ * _(a -> b) -> Either(a) -> Either(b)_
+ */
+export function chain<L, R, U>(f: (value: R) => U): (either: Either<L, R>) => L | U
+export function chain<L, R, U>(f: (value: R) => U, either?: Either<L, R>): L | U | ((either: Either<L, R>) => L | U) {
+  const op = (either: Either<L, R>) => either.chain(f)
   return helpers.curry1(op, either)
 }
 

--- a/src/either.ts
+++ b/src/either.ts
@@ -26,6 +26,18 @@ export function of<L, R>(value: R): Either<L, R> {
   return new Right(value)
 }
 
+export function toString<L, R>(either: Either<L, R>): string {
+  return either.toString()
+}
+
+export function isLeft<L, R>(either: Either<L, R>): boolean {
+  return either.isLeft()
+}
+
+export function isRight<L, R>(either: Either<L, R>): boolean {
+  return either.isRight()
+}
+
 export function fromNullable<L, R>(value: R | L): Either<L, R> {
   if (value === null || value === undefined) {
     return new Left<L, R>(value as L)

--- a/src/either.ts
+++ b/src/either.ts
@@ -9,7 +9,7 @@ export type CaseOf<L, R> = {
 export interface Shape<L, R> {
   map<U>(f: (value: R) => U): Shape<L, U>
   chain<U>(f: (value: R) => U): U | L
-  filter(f: (value: R) => boolean): Shape<L, R>
+  filter(predicate: (value: R) => boolean): Shape<L | R, R >
   getOrElse<U>(defaultValue: U): R | U
   get(): L | R
   toString(): string
@@ -44,14 +44,17 @@ export class Right<L ,R> implements Shape<L ,R> {
     return f(this.value)
   }
 
-  filter(f: (value: R) => boolean): Shape<L, R> {
-    throw new Error("Method not implemented.");
+  filter(predicate: (value: R) => boolean): Shape<L | R, R > {
+    if (predicate(this.value) === true) {
+      return this as Shape<L, R>
+    }
+    return new Left<R, R>(this.value)
   }
-  getOrElse<U>(defaultValue: U): R | U {
-    throw new Error("Method not implemented.");
+  getOrElse<U>(_defaultValue: U): R | U {
+    return this.value
   }
   get(): L | R {
-    throw new Error("Method not implemented.");
+    return this.value
   }
   toString(): string {
     throw new Error("Method not implemented.");
@@ -82,14 +85,14 @@ class Left<L, R> implements  Shape<L, R> {
     return this.value
   }
 
-  filter(f: (value: R) => boolean): Shape<L, R> {
-    throw new Error("Method not implemented.");
+  filter(_predicate: (value: R) => boolean): Shape<L | R, R > {
+    return this
   }
   getOrElse<U>(defaultValue: U): R | U {
-    throw new Error("Method not implemented.");
+    return defaultValue
   }
   get(): L | R {
-    throw new Error("Method not implemented.");
+    return this.value
   }
   toString(): string {
     throw new Error("Method not implemented.");

--- a/src/either.ts
+++ b/src/either.ts
@@ -1,4 +1,4 @@
-// import * as helpers from './helpers'
+import * as helpers from './helpers'
 // import { Nullable } from './types'
 
 export type CaseOf<L, R, U> = {
@@ -6,11 +6,14 @@ export type CaseOf<L, R, U> = {
   Left: (value: L) => U,
 }
 
-export interface Shape<L, R> {
-  map<U>(f: (value: R) => U): Shape<L, U>
+/** This is alias for normal display from context (`Either.Either` => `Either.Shape`) */
+export type Shape<L, R> = Either<L, R>
+
+export interface Either<L, R> {
+  map<U>(f: (value: R) => U): Either<L, U>
   orElse<U>(f: (value: L) => U): U | R
   chain<U>(f: (value: R) => U): U | L
-  filter(predicate: (value: R) => boolean): Shape<L | R, R >
+  filter(predicate: (value: R) => boolean): Either<L | R, R >
   getOrElse<U>(defaultValue: U): R | U
   get(): L | R
   toString(): string
@@ -19,25 +22,59 @@ export interface Shape<L, R> {
   caseOf<U>(matcher: CaseOf<L, R, U>): U
 }
 
-export function of<L, R>(value: R): Shape<L, R> {
+export function of<L, R>(value: R): Either<L, R> {
   return new Right(value)
 }
 
-export function fromNullable<L, R>(value: R | L): Shape<L, R> {
+export function fromNullable<L, R>(value: R | L): Either<L, R> {
   if (value === null || value === undefined) {
     return new Left<L, R>(value as L)
   }
   return new Right<L, R>(value as R)
 }
 
-export class Right<L ,R> implements Shape<L ,R> {
+/**
+ * Method like [`Either.map`](../interfaces/_either_.shape.html#map)
+ *
+ * ```ts
+ * import { Either } from 'monad-maniac'
+ *
+ * const name: string | void = Math.random() > 0.5 ? 'Jake' : undefined
+ * const result: Either.Shape<string, string> = typeof name === 'string'
+ *  ? new Either.Right(name)
+ * : new Either.Left('Server error')
+ * const greeting = Either.map((name) => `Welcome, ${name}!`, result)
+ *
+ * // ...
+ *
+ * if (greeting.isLeft()) {
+ *  console.error(greeting.get())
+ * } else {
+ *  showGreeting(greeting.get())
+ * }
+ *
+ * ```
+ * */
+export function map<L, R, U>(f: (value: R) => U, either: Either<L, R>): Either<L, U>
+/**
+ * Just curried `map`.
+ *
+ * _(a -> b) -> Either(a) -> Either(b)_
+ */
+export function map<L, R, U>(f: (value: R) => U): (either: Either<L, R>) => Either<L, U>
+export function map<L, R, U>(f: (value: R) => U, either?: Either<L, R>): Either<L, U> | ((either: Either<L, R>) => Either<L, U>) {
+  const op = (either: Either<L, R>) => either.map(f)
+  return helpers.curry1(op, either)
+}
+
+export class Right<L ,R> implements Either<L ,R> {
   private value: R
 
   constructor(value: R) {
     this.value = value
   }
 
-  map<U>(f: (value: R) => U): Shape<L, U> {
+  map<U>(f: (value: R) => U): Either<L, U> {
     return of(f(this.value))
   }
 
@@ -49,9 +86,9 @@ export class Right<L ,R> implements Shape<L ,R> {
     return f(this.value)
   }
 
-  filter(predicate: (value: R) => boolean): Shape<L | R, R > {
+  filter(predicate: (value: R) => boolean): Either<L | R, R > {
     if (predicate(this.value) === true) {
-      return this as Shape<L, R>
+      return this as Either<L, R>
     }
     return new Left<R, R>(this.value)
   }
@@ -75,14 +112,14 @@ export class Right<L ,R> implements Shape<L ,R> {
   }
 }
 
-class Left<L, R> implements  Shape<L, R> {
+export class Left<L, R> implements  Either<L, R> {
   private value: L
 
   constructor(value: L) {
     this.value = value
   }
 
-  map<U>(_f: (value: R) => U): Shape<L, U> {
+  map<U>(_f: (value: R) => U): Either<L, U> {
     return new Left<L, U>(this.value)
   }
 
@@ -94,7 +131,7 @@ class Left<L, R> implements  Shape<L, R> {
     return this.value
   }
 
-  filter(_predicate: (value: R) => boolean): Shape<L | R, R > {
+  filter(_predicate: (value: R) => boolean): Either<L | R, R > {
     return this
   }
   getOrElse<U>(defaultValue: U): R | U {

--- a/src/either.ts
+++ b/src/either.ts
@@ -54,6 +54,7 @@ export interface Either<L, R> {
    * Apply some function to value in container. `map` for `Right`
    * will call the function with value, for `Left` return `Left`
    * else value what be returned from the function.
+   *
    * ```ts
    * import { Either } from 'monad-maniac'
    *
@@ -80,7 +81,32 @@ export interface Either<L, R> {
    * @param f Function to apply for Right value
    */
   chain<U>(f: (value: R) => U): U | Either<L, U>
-  filter(predicate: (value: R) => boolean): Either<L | R, R >
+  /**
+ * Apply predicate function to value in container.
+ * If the function returns not `true` then value from
+ * `Right` will be transferred to `Left`.
+ *
+ * ```ts
+ * import { Either } from 'monad-maniac'
+ *
+ * const example = Either.right<number, number>(0)
+ * const result = example.filter((x) => x !== 0).map((x) => 1 / x).get() // 0
+ * ```
+ */
+  filter(predicate: (value: R) => boolean): Either<L | R, R>
+  /**
+   * If `Either` is `Left` returns `defaultValue` and returns `value` from `Right` otherwise.
+   *
+   * ```ts
+   * import { Either } from 'monad-maniac'
+   *
+   * const left = Either.left<number, number>(150)
+   * const right = Either.right<number, number>(150)
+   *
+   * const resultLeft = left.getOrElse(0) // 0
+   * const resultRight = right.getOrElse(0) // 150
+   * ```
+   */
   getOrElse<U>(defaultValue: U): R | U
   get(): L | R
   toString(): string

--- a/src/either.ts
+++ b/src/either.ts
@@ -185,14 +185,33 @@ export interface Either<L, R> {
   caseOf<U>(matcher: CaseOf<L, R, U>): U
 }
 
+/** Alias of  [`Either.right`](../modules/_either_.html#right-2) */
 export function of<L, R>(value: R): Either<L, R> {
   return new Right(value)
 }
 
+/**
+ * Making `Right` from value
+ *
+ * ```ts
+ * import { Either } from 'monad-maniac'
+ *
+ * const left = Either.left<string, number>('Some error')
+ * ```
+ */
 export function left<L, R>(value: L): Either<L, R> {
   return new Left(value)
 }
 
+/**
+ * Making `Right` from value
+ *
+ * ```ts
+ * import { Either } from 'monad-maniac'
+ *
+ * const right = Either.right<string, number>(10)
+ * ```
+ */
 export function right<L, R>(value: R): Either<L, R> {
   return new Right(value)
 }

--- a/src/either.ts
+++ b/src/either.ts
@@ -216,14 +216,53 @@ export function right<L, R>(value: R): Either<L, R> {
   return new Right(value)
 }
 
+/**
+ * Returns `Left` or `Right` as `string`.
+ *
+ * ```ts
+ * import { Either } from 'monad-maniac'
+ *
+ * const right = Either.right<string, number>(10)
+ * const left = Either.left<string, number>('Some error')
+ *
+ * Either.toString(left) // Left(Some error)
+ * Either.toString(right) // Right(10)
+ * ```
+ */
 export function toString<L, R>(either: Either<L, R>): string {
   return either.toString()
 }
 
+/**
+ * Returns `true` if this`Left` or `false` otherwise.
+ *
+ * ```ts
+ * import { Either } from 'monad-maniac'
+ *
+ * const right = Either.right<string, number>(10)
+ * const left = Either.left<string, number>('Some error')
+ *
+ * Either.isLeft(left) // true
+ * Either.isLeft(right) // false
+ * ```
+ */
 export function isLeft<L, R>(either: Either<L, R>): boolean {
   return either.isLeft()
 }
 
+/**
+ * Returns `true` if this`Right` or `false` otherwise.
+ *
+ * ```ts
+ * import { Either } from 'monad-maniac'
+ *
+ * const right = Either.right<string, number>(10)
+ * const left = Either.left<string, number>('Some error')
+ *
+ * Either.isRight(left) // false
+ * Either.isRight(right) // true
+ * ```
+ */
 export function isRight<L, R>(either: Either<L, R>): boolean {
   return either.isRight()
 }

--- a/src/either.ts
+++ b/src/either.ts
@@ -105,6 +105,16 @@ export function getOrElse<L, R, U>(defaultValue: U, either?: Either<L, R>): R | 
   return helpers.curry1(op, either)
 }
 
+export function caseOf<L, R, U>(matcher: CaseOf<L, R, U>, either: Either<L, R>): U
+/**
+ * Just curried `caseOf`.
+ */
+export function caseOf<L, R, U>(matcher: CaseOf<L, R, U>): (either: Either<L, R>) => U
+export function caseOf<L, R, U>(matcher: CaseOf<L, R, U>, either?: Either<L, R>): U | ((either: Either<L, R>) => U) {
+  const op = (either: Either<L, R>) => either.caseOf(matcher)
+  return helpers.curry1(op, either)
+}
+
 export class Right<L ,R> implements Either<L ,R> {
   private value: R
 

--- a/src/either.ts
+++ b/src/either.ts
@@ -1,4 +1,5 @@
-import { Nullable } from './types'
+// import * as helpers from './helpers'
+// import { Nullable } from './types'
 
 export type CaseOf<L, R> = {
   Right: (value: R) => L,
@@ -6,8 +7,8 @@ export type CaseOf<L, R> = {
 }
 
 export interface Shape<L, R> {
-  map<U>(f: (value: NonNullable<R>) => Nullable<U>): Shape<L, NonNullable<U>>
-  chain<U>(f: (value: R) => U): U | undefined
+  map<U>(f: (value: R) => U): Shape<L, U>
+  chain<U>(f: (value: R) => U): U | L
   filter(f: (value: R) => boolean): Shape<L, R>
   getOrElse<U>(defaultValue: U): R | U
   get(): L | R
@@ -15,4 +16,91 @@ export interface Shape<L, R> {
   isLeft(): boolean
   isRight(): boolean
   caseOf<U>(matcher: CaseOf<R, U>): U
+}
+
+export function of<L, R>(value: R): Shape<L, R> {
+  return new Right(value)
+}
+
+export function fromNullable<L, R>(value: R | L): Shape<L, R> {
+  if (value === null || value === undefined) {
+    return new Left<L, R>(value as L)
+  }
+  return new Right<L, R>(value as R)
+}
+
+export class Right<L ,R> implements Shape<L ,R> {
+  private value: R
+
+  constructor(value: R) {
+    this.value = value
+  }
+
+  map<U>(f: (value: R) => U): Shape<L, U> {
+    return of(f(this.value))
+  }
+
+  chain<U>(f: (value: R) => U): U | L {
+    return f(this.value)
+  }
+
+  filter(f: (value: R) => boolean): Shape<L, R> {
+    throw new Error("Method not implemented.");
+  }
+  getOrElse<U>(defaultValue: U): R | U {
+    throw new Error("Method not implemented.");
+  }
+  get(): L | R {
+    throw new Error("Method not implemented.");
+  }
+  toString(): string {
+    throw new Error("Method not implemented.");
+  }
+  isLeft(): boolean {
+    throw new Error("Method not implemented.");
+  }
+  isRight(): boolean {
+    throw new Error("Method not implemented.");
+  }
+  caseOf<U>(matcher: CaseOf<R, U>): U {
+    throw new Error("Method not implemented.");
+  }
+}
+
+class Left<L, R> implements  Shape<L, R> {
+  private value: L
+
+  constructor(value: L) {
+    this.value = value
+  }
+
+  map<U>(_f: (value: R) => U): Shape<L, U> {
+    return new Left<L, U>(this.value)
+  }
+
+  chain<U>(_f: (value: R) => U): U | L {
+    return this.value
+  }
+
+  filter(f: (value: R) => boolean): Shape<L, R> {
+    throw new Error("Method not implemented.");
+  }
+  getOrElse<U>(defaultValue: U): R | U {
+    throw new Error("Method not implemented.");
+  }
+  get(): L | R {
+    throw new Error("Method not implemented.");
+  }
+  toString(): string {
+    throw new Error("Method not implemented.");
+  }
+  isLeft(): boolean {
+    throw new Error("Method not implemented.");
+  }
+  isRight(): boolean {
+    throw new Error("Method not implemented.");
+  }
+  caseOf<U>(matcher: CaseOf<R, U>): U {
+    throw new Error("Method not implemented.");
+  }
 }

--- a/src/either.ts
+++ b/src/either.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '../types'
+import { Nullable } from './types'
 
 export type CaseOf<L, R> = {
   Right: (value: R) => L,

--- a/src/either.ts
+++ b/src/either.ts
@@ -91,14 +91,14 @@ export function orElse<L, R, U>(f: (value: L) => U, either?: Either<L, R>): R | 
   return helpers.curry1(op, either)
 }
 
-export function filter<L, R, U>(predicate: (value: R) => boolean, either: Either<L, R>): Either<L | R, R >
+export function filter<L, R>(predicate: (value: R) => boolean, either: Either<L, R>): Either<L | R, R >
 /**
  * Just curried `filter`.
  *
  * _(a -> b) -> Either(a) -> Either(b)_
  */
-export function filter<L, R, U>(predicate: (value: R) => boolean): (either: Either<L, R>) => Either<L | R, R >
-export function filter<L, R, U>(predicate: (value: R) => boolean, either?: Either<L, R>): Either<L | R, R > | ((either: Either<L, R>) => Either<L | R, R >) {
+export function filter<L, R>(predicate: (value: R) => boolean): (either: Either<L, R>) => Either<L | R, R >
+export function filter<L, R>(predicate: (value: R) => boolean, either?: Either<L, R>): Either<L | R, R > | ((either: Either<L, R>) => Either<L | R, R >) {
   const op = (either: Either<L, R>) => either.filter(predicate)
   return helpers.curry1(op, either)
 }

--- a/src/either.ts
+++ b/src/either.ts
@@ -136,8 +136,52 @@ export interface Either<L, R> {
    * ```
    */
   toString(): string
+  /**
+   * Returns `true` if it's `Left` and `false` otherwise.
+   *
+   * ```ts
+   * import { Either } from 'monad-maniac'
+   *
+   * const left = Either.left<number, number>(300)
+   * const right = Either.right<number, number>(150)
+   *
+   * const resultLeft = left.isLeft() // true
+   * const resultRight = right.isLeft() // false
+   * ```
+   */
   isLeft(): boolean
+  /**
+   * Returns `false` if it's `Left` and `true` otherwise.
+   *
+   * ```ts
+   * import { Either } from 'monad-maniac'
+   *
+   * const left = Either.left<number, number>(300)
+   * const right = Either.right<number, number>(150)
+   *
+   * const resultLeft = left.isRight() // false
+   * const resultRight = right.isRight() // true
+   * ```
+   */
   isRight(): boolean
+  /**
+   * Returns `false` if it's `Left` and `true` otherwise.
+   *
+   * ```ts
+   * import { Either } from 'monad-maniac'
+   *
+   * const left = Either.left<string, number>('Some Error')
+   * const right = Either.right<string, number>(150)
+   *
+   * const matcher: Either.CaseOf<string, number, number> = {
+   *   Right: (x) => x * 2,
+   *   Left: (message) => message.length,
+   * }
+   *
+   * const resultLeft = left.caseOf(matcher) // 10
+   * const resultRight = right.caseOf(matcher) // 300
+   * ```
+   */
   caseOf<U>(matcher: CaseOf<L, R, U>): U
 }
 

--- a/src/either.ts
+++ b/src/either.ts
@@ -15,6 +15,23 @@ export interface Either<L, R> {
    * will call the function with value, for `Left` return `Left`.
    * If `map` will return `null` or `undefined` then return `Right` with that.
    * Be careful.
+   *
+   * ```ts
+   * import { Either } from 'monad-maniac'
+   *
+   * const divide = (dividend: number) => (divider: number): Either.Shape<string, number> => {
+   * if (divider === 0) {
+   *   return Either.left('Divider is zero!')
+   * }
+   *  return Either.right(dividend / divider)
+   * }
+   *
+   * const resultNormal = divide(10)(5).map(double).get() // 4
+   * const resultErrorDivide = divide(10)(0).map(double).get() // 'Divider is zero!'
+   * expect(resultNormal).toBe(4)
+   * expect(resultErrorDivide).toBe('Divider is zero!')
+   * ```
+   *
    * @param f Function to apply for Right value
    */
   map<U>(f: (value: R) => U): Either<L, U>

--- a/src/either.ts
+++ b/src/either.ts
@@ -426,7 +426,7 @@ export function chain<L, R, U>(f: (value: R) => U, either?: Either<L, R>): Eithe
 }
 
 /**
- * Method like [`Either.orElse`](../interfaces/_either_.shape.html#orElse)
+ * Method like [`Either.orElse`](../interfaces/_either_.shape.html#orelse)
  *
  * Apple some function to `Left` value.
  *
@@ -451,6 +451,20 @@ export function orElse<L, R, U>(f: (value: L) => U, either?: Either<L, R>): R | 
   return helpers.curry1(op, either)
 }
 
+/**
+ * Method like [`Either.filter`](../interfaces/_either_.shape.html#filter)
+ *
+ * Apple some function to `Right` value and if the function
+ * returns not `true` then value will be placed to `Left`.
+ *
+ * ```ts
+ * import { Either } from 'monad-maniac'
+ * const right: Either.Shape<number, number> = new Either.Right(150)
+ *
+ * right.filter((x) => x > 150) // Left(150)
+ * right.filter((x) => x < 300) // Right(150)
+ * ```
+ */
 export function filter<L, R>(predicate: (value: R) => boolean, either: Either<L, R>): Either<L | R, R >
 /**
  * Just curried `filter`.
@@ -461,6 +475,19 @@ export function filter<L, R>(predicate: (value: R) => boolean, either?: Either<L
   return helpers.curry1(op, either)
 }
 
+/**
+ * Method like [`Either.getOrElse`](../interfaces/_either_.shape.html#getorelse)
+ *
+ * ```ts
+ * import { Either } from 'monad-maniac'
+ *
+ * const left = Either.left<number, number>(150)
+ * const right = Either.right<number, number>(150)
+ *
+ * const resultLeft = left.getOrElse(0) // 0
+ * const resultRight = right.getOrElse(0) // 150
+ * ```
+ */
 export function getOrElse<L, R, U>(defaultValue: U, either: Either<L, R>): R | U
 /**
  * Just curried `getOrElse`.

--- a/src/either.ts
+++ b/src/either.ts
@@ -82,17 +82,17 @@ export interface Either<L, R> {
    */
   chain<U>(f: (value: R) => U): U | Either<L, U>
   /**
- * Apply predicate function to value in container.
- * If the function returns not `true` then value from
- * `Right` will be transferred to `Left`.
- *
- * ```ts
- * import { Either } from 'monad-maniac'
- *
- * const example = Either.right<number, number>(0)
- * const result = example.filter((x) => x !== 0).map((x) => 1 / x).get() // 0
- * ```
- */
+   * Apply predicate function to value in container.
+   * If the function returns not `true` then value from
+   * `Right` will be transferred to `Left`.
+   *
+   * ```ts
+   * import { Either } from 'monad-maniac'
+   *
+   * const example = Either.right<number, number>(0)
+   * const result = example.filter((x) => x !== 0).map((x) => 1 / x).get() // 0
+   * ```
+   */
   filter(predicate: (value: R) => boolean): Either<L | R, R>
   /**
    * If `Either` is `Left` returns `defaultValue` and returns `value` from `Right` otherwise.
@@ -108,6 +108,19 @@ export interface Either<L, R> {
    * ```
    */
   getOrElse<U>(defaultValue: U): R | U
+  /**
+   * Just returns `value` from `Right` or `Left`
+   *
+   * ```ts
+   * import { Either } from 'monad-maniac'
+   *
+   * const left = Either.left<number, number>(300)
+   * const right = Either.right<number, number>(150)
+   *
+   * const resultLeft = left.get() // 300
+   * const resultRight = right.get() // 150
+   * ```
+   */
   get(): L | R
   toString(): string
   isLeft(): boolean

--- a/src/either.ts
+++ b/src/either.ts
@@ -1,5 +1,5 @@
 import * as helpers from './helpers'
-// import { Nullable } from './types'
+import { Nullable } from './types'
 
 export type CaseOf<L, R, U> = {
   Right: (value: R) => U,
@@ -42,9 +42,9 @@ export function get<L, R>(either: Either<L, R>): L | R {
   return either.get()
 }
 
-export function fromNullable<L, R>(value: R | L): Either<L, R> {
+export function fromNullable<L, R>(value: Nullable<R | L>): Either<Nullable<L>, R> {
   if (value === null || value === undefined) {
-    return new Left<L, R>(value as L)
+    return new Left<Nullable<L>, R>(value as Nullable<L>)
   }
   return new Right<L, R>(value as R)
 }

--- a/src/either.ts
+++ b/src/either.ts
@@ -28,13 +28,27 @@ export interface Either<L, R> {
    *
    * const resultNormal = divide(10)(5).map(double).get() // 4
    * const resultErrorDivide = divide(10)(0).map(double).get() // 'Divider is zero!'
-   * expect(resultNormal).toBe(4)
-   * expect(resultErrorDivide).toBe('Divider is zero!')
    * ```
    *
    * @param f Function to apply for Right value
    */
   map<U>(f: (value: R) => U): Either<L, U>
+    /**
+   * Apply some function to value in container `Left`. Like `map` for `Right`.
+   *
+   * The methods returns result from function or value from `Right`.
+   * ```ts
+   * import { Either } from 'monad-maniac'
+   *
+   * const left = Either.left<Error, string>(new Error('Some error'))
+   * const right = Either.right<Error, string>('Jake')
+   *
+   * const resultLeft = left.orElse((error) => error.message) // Some error
+   * const resultRight = right.orElse((error) => error.message) // Jake
+   * ```
+   *
+   * @param f Function to apply for Right value
+   */
   orElse<U>(f: (value: L) => U): U | R
   /**
    * Apply some function to value in container. `map` for `Right`

--- a/src/either/index.ts
+++ b/src/either/index.ts
@@ -1,17 +1,18 @@
 import { Nullable } from '../types'
 
-export type CaseOf<T, U> = {
-  Right: (value: T) => U,
-  Left: () => U,
+export type CaseOf<L, R> = {
+  Right: (value: R) => L,
+  Left: () => L,
 }
 
-export interface Shape<T> {
-  map<U>(f: (value: NonNullable<T>) => Nullable<U>): Shape<NonNullable<U>>
-  chain<U>(f: (value: T) => U): U | undefined
-  filter(f: (value: T) => boolean): Shape<T>
-  getOrElse<U>(defaultValue: U): T | U
+export interface Shape<L, R> {
+  map<U>(f: (value: NonNullable<R>) => Nullable<U>): Shape<L, NonNullable<U>>
+  chain<U>(f: (value: R) => U): U | undefined
+  filter(f: (value: R) => boolean): Shape<L, R>
+  getOrElse<U>(defaultValue: U): R | U
+  get(): L | R
   toString(): string
   isLeft(): boolean
   isRight(): boolean
-  caseOf<U>(matcher: CaseOf<T, U>): U
+  caseOf<U>(matcher: CaseOf<R, U>): U
 }

--- a/src/either/index.ts
+++ b/src/either/index.ts
@@ -1,0 +1,17 @@
+import { Nullable } from '../types'
+
+export type CaseOf<T, U> = {
+  Right: (value: T) => U,
+  Left: () => U,
+}
+
+export interface Shape<T> {
+  map<U>(f: (value: NonNullable<T>) => Nullable<U>): Shape<NonNullable<U>>
+  chain<U>(f: (value: T) => U): U | undefined
+  filter(f: (value: T) => boolean): Shape<T>
+  getOrElse<U>(defaultValue: U): T | U
+  toString(): string
+  isLeft(): boolean
+  isRight(): boolean
+  caseOf<U>(matcher: CaseOf<T, U>): U
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -2,3 +2,15 @@
 export function curry1<T, U>(op: (a: T) => U, a?: T) {
   return a !== undefined ? op(a) : op;
 }
+
+/**
+ * function _curry1(fn) {
+  return function f1(a) {
+    if (arguments.length === 0 || _isPlaceholder(a)) {
+      return f1;
+    } else {
+      return fn.apply(this, arguments);
+    }
+  };
+}
+ */

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,9 @@
  */
 /** For fix tsdoc */
 import * as Maybe from './maybe'
+import * as Either from './either'
 
 export {
-  Maybe
+  Maybe,
+  Either,
 }

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -401,7 +401,27 @@ export function chain<T, U>(f: (value: T) => U, maybe?: MaybeShape<T>): U | unde
  * ```ts
  * import { Maybe } from 'monad-maniac'
  *
- * const foo = Maybe.of(12)
+ * const  find = <T>(list: T[]) => (predicate: (v: T) => boolean) => list.find(predicate)
+ *
+ * type DataItem = {
+ *   id: number
+ *   name: string
+ * }
+ *
+ * const data: DataItem[] = [{ id: 1, name: 'Jayson' }, { id: 2, name: 'Michael' }]
+ * const safeFindInList = Maybe.lift(find(data))
+ *
+ * const resultJust = safeFindInList(({ id }) => id === 1) // Just([object Object])
+ * const resultNothing = safeFindInList(({ id }) => id === 10) // Nothing()
+ *
+ * const matcher: Maybe.CaseOf<DataItem, string> = {
+ *  Just: ({ name }) => name,
+ *  Nothing: () => 'UNKNOWN'
+ * }
+ *
+ * console.log(resultJust.caseOf(matcher)) // 'Jayson'
+ * console.log(resultNothing.caseOf(matcher)) // 'UNKNOWN'
+ *
  * ```
  * */
 export function lift<T, U>(f: (value: T) => Nullable<U>, value: Nullable<T>): MaybeShape<NonNullable<U>>

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -395,6 +395,31 @@ export function chain<T, U>(f: (value: T) => U, maybe?: MaybeShape<T>): U | unde
   return helpers.curry1(op, maybe)
 }
 
+/**
+ * List function
+ *
+ * ```ts
+ * import { Maybe } from 'monad-maniac'
+ *
+ * const foo = Maybe.of(12)
+ * ```
+ * */
+export function lift<T, U>(f: (value: T) => Nullable<U>, value: Nullable<T>): MaybeShape<NonNullable<U>>
+/**
+ * Just curried `lift`.
+ *
+ * _(a -> b) -> a -> Maybe(b)_
+ */
+export function lift<T, U>(f: (value: T) => Nullable<U>): (value: Nullable<T>) => MaybeShape<NonNullable<U>>
+export function lift<T, U>(f: (value: T) => Nullable<U>, value?: Nullable<T>): MaybeShape<NonNullable<U>> | ((value: Nullable<T>) => MaybeShape<NonNullable<U>>) {
+  const op = (value: Nullable<T>) => of(value).map(f)
+  if (arguments.length > 1) {
+    return op(value)
+  } else {
+    return op
+  }
+}
+
 
 /**
  * Method like [`MaybeShape.equals`](../interfaces/_maybe_.maybeshape.html#equals)

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -396,7 +396,8 @@ export function chain<T, U>(f: (value: T) => U, maybe?: MaybeShape<T>): U | unde
 }
 
 /**
- * List function
+ * Lift function - contain function in wrapper for returning `Maybe`.
+ * If function will return `null` or `undefined`, you get `Nothing`, else `Just(some)`.
  *
  * ```ts
  * import { Maybe } from 'monad-maniac'

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -1,6 +1,5 @@
 import * as helpers from './helpers'
-
-type Nullable<T> = T | null | undefined
+import { Nullable } from './types'
 
 type ApplicativeResult<T, U extends ((value: T) => any)> = MaybeShape<ReturnType<U>>
 

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -59,7 +59,7 @@ export interface Maybe<T> {
    * console.log(result) // undefined
    * ```
    */
-  chain<U>(f: (value: T) => U): U | undefined
+  chain<U>(f: (value: T) => U): U | Maybe<T>
 
   /** Return true if `Nothing` */
   isNothing(): boolean
@@ -386,14 +386,14 @@ export function caseOf<T, U>(matcher: CaseOf<T, U>, maybe?: Maybe<T>): U | ((may
  * const resultFoo = Maybe.chain(foo, (x) => x * x) // 144
  * ```
  * */
-export function chain<T, U>(f: (value: T) => U, maybe: Maybe<T>): U | undefined
+export function chain<T, U>(f: (value: T) => U, maybe: Maybe<T>): U | Maybe<T>
 /**
  * Just curried `chain`.
  *
  * _(a -> b) -> Maybe(a) -> b_
  */
-export function chain<T, U>(f: (value: T) => U): (maybe: Maybe<T>) => U | undefined
-export function chain<T, U>(f: (value: T) => U, maybe?: Maybe<T>): U | undefined | ((maybe: Maybe<T>) => U | undefined) {
+export function chain<T, U>(f: (value: T) => U): (maybe: Maybe<T>) => U | Maybe<T>
+export function chain<T, U>(f: (value: T) => U, maybe?: Maybe<T>): U | Maybe<T> | ((maybe: Maybe<T>) => U | Maybe<T>) {
   const op = (m: Maybe<T>) => m.chain(f)
   return helpers.curry1(op, maybe)
 }
@@ -590,8 +590,8 @@ export class Nothing<T> implements Maybe<T> {
   }
 
   /** Method implements from [`Maybe.chain`](../interfaces/_maybe_.maybeshape.html#chain) */
-  chain<U>(_f: (value: T) => U): undefined {
-    return undefined
+  chain<U>(_f: (value: T) => U): Maybe<T> {
+    return this
   }
 
   filter(_f: (value: T) => boolean): Maybe<T> {

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -56,7 +56,7 @@ export interface Maybe<T> {
    *  .filter((x) => x > 1000) // Nothing() - next function will be called never
    *  .map((x) => x + 10) // 60
    *  .chain((x) => x / 3) // 20 - actually the function will not be called
-   * console.log(result) // undefined
+   * console.log(result) // Nothing()
    * ```
    */
   chain<U>(f: (value: T) => U): U | Maybe<T>

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -2,7 +2,7 @@ import * as helpers from './helpers'
 
 type Nullable<T> = T | null | undefined
 
-type ApplicativeResult<T, U extends ((value: T) => any)> = MaybeShape<NonNullable<ReturnType<U>>>
+type ApplicativeResult<T, U extends ((value: T) => any)> = MaybeShape<ReturnType<U>>
 
 type JoinMaybe<T> = T extends MaybeShape<any> ? T : MaybeShape<T>
 

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -137,13 +137,13 @@ export interface MaybeShape<T> {
    * const brokenDataMaybe = Maybe.of<number>(null)
    * const normalDataMaybe = Maybe.of(10)
    *
-   * const mather: Maybe.CaseOf<number> = {
+   * const matcher: Maybe.CaseOf<number> = {
    *  Just: (x) => x * x,
    *  Nothing: () => -1,
    * }
    *
-   * const unwrappedNormal = normalDataMaybe.caseOf(mather) // 100
-   * const unwrappedBroken = normalDataMaybe.caseOf(mather) // -1
+   * const unwrappedNormal = normalDataMaybe.caseOf(matcher) // 100
+   * const unwrappedBroken = normalDataMaybe.caseOf(matcher) // -1
    *
    * // More example:
    *
@@ -157,9 +157,9 @@ export interface MaybeShape<T> {
    *  Nothing: () => Maybe.of(-1),
    * }).map((x) => x ^ 2) // Nothing
    * ```
-   * @param mather This is object with two fields `Just` and `Nothing` what contains functions.
+   * @param matcher This is object with two fields `Just` and `Nothing` what contains functions.
    */
-  caseOf<U>(mather: CaseOf<T, U>): U
+  caseOf<U>(matcher: CaseOf<T, U>): U
 
   /**
    * Unwrap `Maybe` from `Maybe`, if in `Maybe` will not `Maybe` then returns `Nothing`.
@@ -338,13 +338,13 @@ export function map<T, U>(f: (value: T) => Nullable<U>, maybe?: MaybeShape<T>): 
    * const brokenDataMaybe = Maybe.of<number>(null)
    * const normalDataMaybe = Maybe.of(10)
    *
-   * const mather: Maybe.CaseOf<number> = {
+   * const matcher: Maybe.CaseOf<number> = {
    *  Just: (x) => x * x,
    *  Nothing: () => -1,
    * }
    *
-   * const unwrappedNormal = Maybe.caseOf(mather, brokenDataMaybe) // 100
-   * const unwrappedBroken = Maybe.caseOf(mather, normalDataMaybe) // -1
+   * const unwrappedNormal = Maybe.caseOf(matcher, brokenDataMaybe) // 100
+   * const unwrappedBroken = Maybe.caseOf(matcher, normalDataMaybe) // -1
    *
    * // More example:
    *
@@ -358,7 +358,7 @@ export function map<T, U>(f: (value: T) => Nullable<U>, maybe?: MaybeShape<T>): 
    *  Nothing: () => Maybe.of(-1),
    * }).map((x) => x ^ 2) // Nothing
    * ```
-   * @param mather This is object with two fields `Just` and `Nothing` what contains functions.
+   * @param matcher This is object with two fields `Just` and `Nothing` what contains functions.
  * */
 export function caseOf<T, U>(matcher: CaseOf<T, U>, maybe: MaybeShape<T>): U
 /**
@@ -541,8 +541,8 @@ export class Just<T> implements MaybeShape<T> {
   }
 
   /** Method implements from [`MaybeShape.caseOf`](../interfaces/_maybe_.maybeshape.html#caseof) */
-  caseOf<U>(mather: CaseOf<T, U>): U {
-    return mather.Just(this.value)
+  caseOf<U>(matcher: CaseOf<T, U>): U {
+    return matcher.Just(this.value)
   }
 
   /** Method implements from [`MaybeShape.join`](../interfaces/_maybe_.maybeshape.html#join) */
@@ -605,8 +605,8 @@ export class Nothing<T> implements MaybeShape<T> {
   }
 
   /** Method implements from [`MaybeShape.caseOf`](../interfaces/_maybe_.maybeshape.html#caseof) */
-  caseOf<U>(mather: CaseOf<T, U>): U {
-    return mather.Nothing()
+  caseOf<U>(matcher: CaseOf<T, U>): U {
+    return matcher.Nothing()
   }
 
   /** Method implements from [`MaybeShape.join`](../interfaces/_maybe_.maybeshape.html#join) */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,1 @@
+export type Nullable<T> = T | null | undefined

--- a/tests/either.test.ts
+++ b/tests/either.test.ts
@@ -225,11 +225,6 @@ describe('Either pure functions', () => {
 })
 
 describe('Either: Left & Right', () => {
-  // const foo: string = 'foo'
-  // const bar: string = 'bar'
-  // const baz: string = 'baz'
-  // const randomNumber: number = Math.round(Math.random() * 100)
-
   it('get', () => {
     const left: Either.Shape<string, number> = new Either.Left('Server error')
     const right: Either.Shape<string, number> = new Either.Right(150)

--- a/tests/either.test.ts
+++ b/tests/either.test.ts
@@ -380,4 +380,22 @@ describe('Cases from docs', () => {
     expect(resultLeft).toBe('Some error')
     expect(resultRight).toBe('Jake')
   })
+
+  it('filter', () => {
+    const example = Either.right<number, number>(0)
+    const result = example.filter((x) => x !== 0).map((x) => 1 / x).get() // 0
+
+    expect(result).toBe(0)
+  })
+
+  it('getOrElse', () => {
+    const left = Either.left<number, number>(150)
+    const right = Either.right<number, number>(150)
+
+    const resultLeft = left.getOrElse(0) // 0
+    const resultRight = right.getOrElse(0) // 150
+
+    expect(resultLeft).toBe(0)
+    expect(resultRight).toBe(150)
+  })
 })

--- a/tests/either.test.ts
+++ b/tests/either.test.ts
@@ -178,6 +178,25 @@ describe('Either pure functions', () => {
       expect(Either.filter(predicate)(right.map(double)).isRight()).toBe(true)
     })
   })
+
+  describe('attempt', () => {
+    const errorFunction = (x: number): number => {
+      if (x === 0) {
+        throw new Error('Number is zero!')
+      }
+      return x
+    }
+
+    it('direct call', () => {
+      expect(Either.attempt(errorFunction, [0]).map(double).toString()).toBe('Left(Error: Number is zero!)')
+      expect(Either.attempt(errorFunction, [10]).map(double).toString()).toBe('Right(20)')
+    })
+
+    it('carried', () => {
+      expect(Either.attempt(errorFunction)([0]).map(double).toString()).toBe('Left(Error: Number is zero!)')
+      expect(Either.attempt(errorFunction)([10]).map(double).toString()).toBe('Right(20)')
+    })
+  })
 })
 
 describe('Either: Left & Right', () => {

--- a/tests/either.test.ts
+++ b/tests/either.test.ts
@@ -10,6 +10,18 @@ describe('Either pure functions', () => {
     })
   })
 
+  describe('left', () => {
+    it('direct call', () => {
+      expect(Either.left<string, number>('Server Error').toString()).toBe('Left(Server Error)')
+    })
+  })
+
+  describe('right', () => {
+    it('direct call', () => {
+      expect(Either.right<string, number>(10).toString()).toBe('Right(10)')
+    })
+  })
+
   describe('fromNullable', () => {
     it('direct call', () => {
       expect(Either.fromNullable<string, number>(150).toString()).toBe('Right(150)')

--- a/tests/either.test.ts
+++ b/tests/either.test.ts
@@ -84,16 +84,18 @@ describe('Either pure functions', () => {
     it('direct call', () => {
       const left: Either.Shape<string, number> = new Either.Left('Server error')
       const right: Either.Shape<string, number> = new Either.Right(150)
+      const leftResult = Either.chain(double, left)
 
-      expect(Either.chain(double, left)).toBe('Server error')
+      expect(leftResult instanceof Either.Left).toBe(true)
       expect(Either.chain(double, right)).toBe(300)
     })
 
     it('carried', () => {
       const left: Either.Shape<string, number> = new Either.Left('Server error')
       const right: Either.Shape<string, number> = new Either.Right(150)
+      const leftResult = Either.chain(double)(left)
 
-      expect(Either.chain(double)(left)).toBe('Server error')
+      expect(leftResult instanceof Either.Left).toBe(true)
       expect(Either.chain(double)(right)).toBe(300)
     })
   })
@@ -267,7 +269,7 @@ describe('Either: Left & Right', () => {
     const left: Either.Shape<string, number> = new Either.Left('Server error')
     const right: Either.Shape<string, number> = new Either.Right(150)
 
-    expect(left.chain(double)).toBe('Server error')
+    expect(left.chain(double) instanceof Either.Left).toBe(true)
     expect(right.chain(double)).toBe(300)
   })
 

--- a/tests/either.test.ts
+++ b/tests/either.test.ts
@@ -339,6 +339,20 @@ describe('Cases from docs', () => {
      return Either.right(dividend / divider)
     }
 
+    const resultNormal = divide(10)(5).map(double).get() // 4
+    const resultErrorDivide = divide(10)(0).map(double).get() // 'Divider is zero!'
+    expect(resultNormal).toBe(4)
+    expect(resultErrorDivide).toBe('Divider is zero!')
+  })
+
+  it('chain', () => {
+    const divide = (dividend: number) => (divider: number): Either.Shape<string, number> => {
+     if (divider === 0) {
+       return Either.left('Divider is zero!')
+     }
+     return Either.right(dividend / divider)
+    }
+
     const nonZeroMultiply = (multiplicand: number) => (factor: number): Either.Shape<string, number> => {
       if (factor === 0) {
         return Either.left('Factor is zero!')

--- a/tests/either.test.ts
+++ b/tests/either.test.ts
@@ -1,0 +1,36 @@
+import { Either } from '../src'
+
+const double = (x: number): number => x * 2
+
+describe('Either: Left & Right', () => {
+  // const foo: string = 'foo'
+  // const bar: string = 'bar'
+  // const baz: string = 'baz'
+  // const randomNumber: number = Math.round(Math.random() * 100)
+
+  it('get', () => {
+    const left: Either.Shape<string, number> = new Either.Left('Server error')
+    const right: Either.Shape<string, number> = new Either.Right(150)
+
+    expect(left.get()).toBe('Server error')
+    expect(right.get()).toBe(150)
+  })
+
+  it('map', () => {
+    const left: Either.Shape<string, number> = new Either.Left('Server error')
+    const right: Either.Shape<string, number> = new Either.Right(150)
+
+    expect(left.map(double).get()).toBe('Server error')
+    expect(right.map(double).get()).toBe(300)
+  })
+
+  it('orElse', () => {
+    const left: Either.Shape<string, number> = new Either.Left('Server error')
+    const right: Either.Shape<string, number> = new Either.Right(150)
+
+    const orElse = (message: string) => ({ message })
+
+    expect(left.orElse(orElse)).toEqual({ message: 'Server error' })
+    expect(right.orElse(orElse)).toBe(150)
+  })
+})

--- a/tests/either.test.ts
+++ b/tests/either.test.ts
@@ -197,6 +197,31 @@ describe('Either pure functions', () => {
       expect(Either.attempt(errorFunction)([10]).map(double).toString()).toBe('Right(20)')
     })
   })
+
+  describe('asyncAttempt', () => {
+    const errorAsyncFunction = (x: number): Promise<number> => new Promise((resolve, reject) => {
+      if (x === 0) {
+        reject(new Error('Number is zero!'))
+      }
+      resolve(x)
+    })
+
+    it('direct call', async () => {
+      const left = await Either.asyncAttempt(errorAsyncFunction, [0])
+      const right = await Either.asyncAttempt(errorAsyncFunction, [10])
+      expect(left.map(double).toString()).toBe('Left(Error: Number is zero!)')
+      expect(right.map(double).toString()).toBe('Right(20)')
+    })
+
+    it('carried', async () => {
+      const leftErrorFn = Either.asyncAttempt(errorAsyncFunction)
+      const rightErrorFn = Either.asyncAttempt(errorAsyncFunction)
+      const left = await leftErrorFn([0])
+      const right = await rightErrorFn([10])
+      expect(left.map(double).toString()).toBe('Left(Error: Number is zero!)')
+      expect(right.map(double).toString()).toBe('Right(20)')
+    })
+  })
 })
 
 describe('Either: Left & Right', () => {

--- a/tests/either.test.ts
+++ b/tests/either.test.ts
@@ -3,6 +3,23 @@ import { Either } from '../src'
 const double = (x: number): number => x * 2
 
 describe('Either pure functions', () => {
+  describe('of', () => {
+    it('direct call', () => {
+      expect(Either.of(150).toString()).toBe('Right(150)')
+      expect(Either.of('right').toString()).toBe('Right(right)')
+    })
+  })
+
+  describe('fromNullable', () => {
+    it('direct call', () => {
+      expect(Either.fromNullable<string, number>(150).toString()).toBe('Right(150)')
+      expect(Either.fromNullable<string, string>('right').toString()).toBe('Right(right)')
+      expect(Either.fromNullable<string, string>(null).toString()).toBe('Left(null)')
+      expect(Either.fromNullable<string, string>(undefined).toString()).toBe('Left(undefined)')
+      expect(Either.fromNullable<string, string>(undefined).orElse(() => Either.of('gog')).toString()).toBe('Right(gog)')
+    })
+  })
+
   describe('get', () => {
     it('direct call', () => {
       const left: Either.Shape<string, number> = new Either.Left('Server error')

--- a/tests/either.test.ts
+++ b/tests/either.test.ts
@@ -96,6 +96,26 @@ describe('Either pure functions', () => {
       expect(Either.toString(right)).toBe('Right(150)')
     })
   })
+
+  describe('isLeft', () => {
+    it('direct call', () => {
+      const left: Either.Shape<string, number> = new Either.Left('Server error')
+      const right: Either.Shape<string, number> = new Either.Right(150)
+
+      expect(Either.isLeft(left)).toBe(true)
+      expect(Either.isLeft(right)).toBe(false)
+    })
+  })
+
+  describe('isRight', () => {
+    it('direct call', () => {
+      const left: Either.Shape<string, number> = new Either.Left('Server error')
+      const right: Either.Shape<string, number> = new Either.Right(150)
+
+      expect(Either.isRight(left)).toBe(false)
+      expect(Either.isRight(right)).toBe(true)
+    })
+  })
 })
 
 describe('Either: Left & Right', () => {

--- a/tests/either.test.ts
+++ b/tests/either.test.ts
@@ -2,6 +2,56 @@ import { Either } from '../src'
 
 const double = (x: number): number => x * 2
 
+describe('Either pure functions', () => {
+  describe('get', () => {
+    it('direct call', () => {
+      const left: Either.Shape<string, number> = new Either.Left('Server error')
+      const right: Either.Shape<string, number> = new Either.Right(150)
+
+      expect(Either.get(left)).toBe('Server error')
+      expect(Either.get(right)).toBe(150)
+    })
+  })
+
+  describe('map', () => {
+    it('direct call', () => {
+      const left: Either.Shape<string, number> = new Either.Left('Server error')
+      const right: Either.Shape<string, number> = new Either.Right(150)
+
+      expect(Either.map(double, left).get()).toBe('Server error')
+      expect(Either.map(double, right).get()).toBe(300)
+    })
+
+    it('carried', () => {
+      const left: Either.Shape<string, number> = new Either.Left('Server error')
+      const right: Either.Shape<string, number> = new Either.Right(150)
+
+      expect(Either.map(double)(left).get()).toBe('Server error')
+      expect(Either.map(double)(right).get()).toBe(300)
+    })
+  })
+
+  describe('orElse', () => {
+    const orElse = (message: string) => ({ message })
+
+    it('direct call', () => {
+      const left: Either.Shape<string, number> = new Either.Left('Server error')
+      const right: Either.Shape<string, number> = new Either.Right(150)
+
+      expect(Either.orElse(orElse, left)).toEqual({ message: 'Server error' })
+      expect(Either.orElse(orElse, right)).toBe(150)
+    })
+
+    it('carried', () => {
+      const left: Either.Shape<string, number> = new Either.Left('Server error')
+      const right: Either.Shape<string, number> = new Either.Right(150)
+
+      expect(Either.orElse(orElse)(left)).toEqual({ message: 'Server error' })
+      expect(Either.orElse(orElse)(right)).toBe(150)
+    })
+  })
+})
+
 describe('Either: Left & Right', () => {
   // const foo: string = 'foo'
   // const bar: string = 'bar'

--- a/tests/either.test.ts
+++ b/tests/either.test.ts
@@ -431,4 +431,20 @@ describe('Cases from docs', () => {
     expect(resultLeft).toBe(false)
     expect(resultRight).toBe(true)
   })
+
+  it('caseOf', () => {
+    const left = Either.left<string, number>('Some Error')
+    const right = Either.right<string, number>(150)
+
+    const matcher: Either.CaseOf<string, number, number> = {
+      Right: (x) => x * 2,
+      Left: (message) => message.length,
+    }
+
+    const resultLeft = left.caseOf(matcher) // 10
+    const resultRight = right.caseOf(matcher) // 300
+
+    expect(resultLeft).toBe(10)
+    expect(resultRight).toBe(300)
+  })
 })

--- a/tests/either.test.ts
+++ b/tests/either.test.ts
@@ -33,4 +33,44 @@ describe('Either: Left & Right', () => {
     expect(left.orElse(orElse)).toEqual({ message: 'Server error' })
     expect(right.orElse(orElse)).toBe(150)
   })
+
+  it('chain', () => {
+    const left: Either.Shape<string, number> = new Either.Left('Server error')
+    const right: Either.Shape<string, number> = new Either.Right(150)
+
+    expect(left.chain(double)).toBe('Server error')
+    expect(right.chain(double)).toBe(300)
+  })
+
+  it('getOrElse', () => {
+    const left: Either.Shape<string, number> = new Either.Left('Server error')
+    const right: Either.Shape<string, number> = new Either.Right(150)
+
+    expect(left.getOrElse(-1)).toBe(-1)
+    expect(right.getOrElse(-1)).toBe(150)
+  })
+
+  it('toString', () => {
+    const left: Either.Shape<string, number> = new Either.Left('Server error')
+    const right: Either.Shape<string, number> = new Either.Right(150)
+
+    expect(left.toString()).toBe('Left(Server error)')
+    expect(right.toString()).toBe('Right(150)')
+  })
+
+  it('isLeft', () => {
+    const left: Either.Shape<string, number> = new Either.Left('Server error')
+    const right: Either.Shape<string, number> = new Either.Right(150)
+
+    expect(left.isLeft()).toBe(true)
+    expect(right.isLeft()).toBe(false)
+  })
+
+  it('isRight', () => {
+    const left: Either.Shape<string, number> = new Either.Left('Server error')
+    const right: Either.Shape<string, number> = new Either.Right(150)
+
+    expect(left.isRight()).toBe(false)
+    expect(right.isRight()).toBe(true)
+  })
 })

--- a/tests/either.test.ts
+++ b/tests/either.test.ts
@@ -398,4 +398,15 @@ describe('Cases from docs', () => {
     expect(resultLeft).toBe(0)
     expect(resultRight).toBe(150)
   })
+
+  it('get', () => {
+    const left = Either.left<number, number>(300)
+    const right = Either.right<number, number>(150)
+
+    const resultLeft = left.get() // 300
+    const resultRight = right.get() // 150
+
+    expect(resultLeft).toBe(300)
+    expect(resultRight).toBe(150)
+  })
 })

--- a/tests/either.test.ts
+++ b/tests/either.test.ts
@@ -329,3 +329,30 @@ describe('Either: Left & Right', () => {
     expect(right.filter(predicate).map(double).isLeft()).toBe(true)
   })
 })
+
+describe('Cases from docs', () => {
+  it('map', () => {
+    const divide = (dividend: number) => (divider: number): Either.Shape<string, number> => {
+     if (divider === 0) {
+       return Either.left('Divider is zero!')
+     }
+     return Either.right(dividend / divider)
+    }
+
+    const nonZeroMultiply = (multiplicand: number) => (factor: number): Either.Shape<string, number> => {
+      if (factor === 0) {
+        return Either.left('Factor is zero!')
+      }
+      return Either.right(multiplicand * factor)
+    }
+
+    const resultNormal = divide(10)(2).chain(nonZeroMultiply(20)).get() // 100
+    const resultErrorDivide = divide(10)(0).chain(nonZeroMultiply(20)).get() // 'Divider is zero!'
+    const resultErrorMultiply = divide(0)(2).chain(nonZeroMultiply(20)).get() // 'Factor is zero!'
+    const resultError = divide(0)(0).chain(nonZeroMultiply(20)).get() // 'Divider is zero!'
+    expect(resultNormal).toBe(100)
+    expect(resultErrorDivide).toBe('Divider is zero!')
+    expect(resultErrorMultiply).toBe('Factor is zero!')
+    expect(resultError).toBe('Divider is zero!')
+  })
+})

--- a/tests/either.test.ts
+++ b/tests/either.test.ts
@@ -247,4 +247,15 @@ describe('Either: Left & Right', () => {
     expect(left.caseOf(matcher)).toBe(12)
     expect(right.caseOf(matcher)).toBe(300)
   })
+
+  it('filter', () => {
+    const predicate = (x: number) => x > 150
+    const left: Either.Shape<number, number> = new Either.Left(150)
+    const right: Either.Shape<number, number> = new Either.Right(150)
+
+    expect(left.map(double).filter(predicate).isLeft()).toBe(true)
+    expect(right.filter(predicate).isLeft()).toBe(true)
+    expect(right.map(double).filter(predicate).isRight()).toBe(true)
+    expect(right.filter(predicate).map(double).isLeft()).toBe(true)
+  })
 })

--- a/tests/either.test.ts
+++ b/tests/either.test.ts
@@ -73,4 +73,17 @@ describe('Either: Left & Right', () => {
     expect(left.isRight()).toBe(false)
     expect(right.isRight()).toBe(true)
   })
+
+  it('caseOf', () => {
+    const left: Either.Shape<string, number> = new Either.Left('Server error')
+    const right: Either.Shape<string, number> = new Either.Right(150)
+
+    const matcher: Either.CaseOf<string, number, number> = {
+      Right: double,
+      Left: (message) => message.length,
+    }
+
+    expect(left.caseOf(matcher)).toBe(12)
+    expect(right.caseOf(matcher)).toBe(300)
+  })
 })

--- a/tests/either.test.ts
+++ b/tests/either.test.ts
@@ -116,6 +116,51 @@ describe('Either pure functions', () => {
       expect(Either.isRight(right)).toBe(true)
     })
   })
+
+  describe('caseOf', () => {
+    const matcher: Either.CaseOf<string, number, number> = {
+      Right: double,
+      Left: (message) => message.length,
+    }
+
+    it('direct call', () => {
+      const left: Either.Shape<string, number> = new Either.Left('Server error')
+      const right: Either.Shape<string, number> = new Either.Right(150)
+
+      expect(Either.caseOf(matcher, left)).toBe(12)
+      expect(Either.caseOf(matcher, right)).toBe(300)
+    })
+
+    it('carried', () => {
+      const left: Either.Shape<string, number> = new Either.Left('Server error')
+      const right: Either.Shape<string, number> = new Either.Right(150)
+
+      expect(Either.caseOf(matcher)(left)).toBe(12)
+      expect(Either.caseOf(matcher)(right)).toBe(300)
+    })
+  })
+
+  describe('filter', () => {
+    const predicate = (x: number) => x > 150
+
+    it('direct call', () => {
+      const left: Either.Shape<number, number> = new Either.Left(150)
+      const right: Either.Shape<number, number> = new Either.Right(150)
+
+      expect(Either.filter(predicate, left.map(double)).isLeft()).toBe(true)
+      expect(Either.filter(predicate, right).isLeft()).toBe(true)
+      expect(Either.filter(predicate, right.map(double)).isRight()).toBe(true)
+    })
+
+    it('carried', () => {
+      const left: Either.Shape<number, number> = new Either.Left(150)
+      const right: Either.Shape<number, number> = new Either.Right(150)
+
+      expect(Either.filter(predicate)(left.map(double)).isLeft()).toBe(true)
+      expect(Either.filter(predicate)(right).isLeft()).toBe(true)
+      expect(Either.filter(predicate)(right.map(double)).isRight()).toBe(true)
+    })
+  })
 })
 
 describe('Either: Left & Right', () => {

--- a/tests/either.test.ts
+++ b/tests/either.test.ts
@@ -50,6 +50,52 @@ describe('Either pure functions', () => {
       expect(Either.orElse(orElse)(right)).toBe(150)
     })
   })
+
+  describe('chain', () => {
+    it('direct call', () => {
+      const left: Either.Shape<string, number> = new Either.Left('Server error')
+      const right: Either.Shape<string, number> = new Either.Right(150)
+
+      expect(Either.chain(double, left)).toBe('Server error')
+      expect(Either.chain(double, right)).toBe(300)
+    })
+
+    it('carried', () => {
+      const left: Either.Shape<string, number> = new Either.Left('Server error')
+      const right: Either.Shape<string, number> = new Either.Right(150)
+
+      expect(Either.chain(double)(left)).toBe('Server error')
+      expect(Either.chain(double)(right)).toBe(300)
+    })
+  })
+
+  describe('getOrElse', () => {
+    it('direct call', () => {
+      const left: Either.Shape<string, number> = new Either.Left('Server error')
+      const right: Either.Shape<string, number> = new Either.Right(150)
+
+      expect(Either.getOrElse('no-o-o', left)).toBe('no-o-o')
+      expect(Either.getOrElse('no-o-o', right)).toBe(150)
+    })
+
+    it('carried', () => {
+      const left: Either.Shape<string, number> = new Either.Left('Server error')
+      const right: Either.Shape<string, number> = new Either.Right(150)
+
+      expect(Either.getOrElse('no-o-o')(left)).toBe('no-o-o')
+      expect(Either.getOrElse('no-o-o')(right)).toBe(150)
+    })
+  })
+
+  describe('toString', () => {
+    it('direct call', () => {
+      const left: Either.Shape<string, number> = new Either.Left('Server error')
+      const right: Either.Shape<string, number> = new Either.Right(150)
+
+      expect(Either.toString(left)).toBe('Left(Server error)')
+      expect(Either.toString(right)).toBe('Right(150)')
+    })
+  })
 })
 
 describe('Either: Left & Right', () => {

--- a/tests/either.test.ts
+++ b/tests/either.test.ts
@@ -403,10 +403,32 @@ describe('Cases from docs', () => {
     const left = Either.left<number, number>(300)
     const right = Either.right<number, number>(150)
 
-    const resultLeft = left.get() // 300
-    const resultRight = right.get() // 150
+    const resultLeft = left.toString() // Left(300)
+    const resultRight = right.toString() // Right(150)
 
-    expect(resultLeft).toBe(300)
-    expect(resultRight).toBe(150)
+    expect(resultLeft).toBe('Left(300)')
+    expect(resultRight).toBe('Right(150)')
+  })
+
+  it('isLeft', () => {
+    const left = Either.left<number, number>(300)
+    const right = Either.right<number, number>(150)
+
+    const resultLeft = left.isLeft() // true
+    const resultRight = right.isLeft() // false
+
+    expect(resultLeft).toBe(true)
+    expect(resultRight).toBe(false)
+  })
+
+  it('isRight', () => {
+    const left = Either.left<number, number>(300)
+    const right = Either.right<number, number>(150)
+
+    const resultLeft = left.isRight() // false
+    const resultRight = right.isRight() // true
+
+    expect(resultLeft).toBe(false)
+    expect(resultRight).toBe(true)
   })
 })

--- a/tests/either.test.ts
+++ b/tests/either.test.ts
@@ -369,4 +369,15 @@ describe('Cases from docs', () => {
     expect(resultErrorMultiply).toBe('Factor is zero!')
     expect(resultError).toBe('Divider is zero!')
   })
+
+  it('orElse', () => {
+    const left = Either.left<Error, string>(new Error('Some error'))
+    const right = Either.right<Error, string>('Jake')
+
+    const resultLeft = left.orElse((error) => error.message) // Some error
+    const resultRight = right.orElse((error) => error.message) // Jake
+
+    expect(resultLeft).toBe('Some error')
+    expect(resultRight).toBe('Jake')
+  })
 })

--- a/tests/maybe.test.ts
+++ b/tests/maybe.test.ts
@@ -244,6 +244,29 @@ describe('Pure functions', () => {
       expect(safeFind(data).toString()).toBe('Just([object Object])')
       expect(safeFindNothing(data).toString()).toBe('Nothing()')
     })
+
+    it('case from docs', () => {
+      const  find = <T>(list: T[]) => (predicate: (v: T) => boolean) => list.find(predicate)
+
+      type DataItem = {
+        id: number
+        name: string
+      }
+
+      const data: DataItem[] = [{ id: 1, name: 'Jayson' }, { id: 2, name: 'Michael' }]
+      const safeFindInList = Maybe.lift(find(data))
+
+      const resultJust = safeFindInList(({ id }) => id === 1) // Just([object Object])
+      const resultNothing = safeFindInList(({ id }) => id === 10) // Nothing()
+
+      const matcher: Maybe.CaseOf<DataItem, string> = {
+       Just: ({ name }) => name,
+       Nothing: () => 'UNKNOWN'
+      }
+
+      expect(resultJust.caseOf(matcher)).toBe('Jayson')
+      expect(resultNothing.caseOf(matcher)).toBe('UNKNOWN')
+    })
   })
 })
 

--- a/tests/maybe.test.ts
+++ b/tests/maybe.test.ts
@@ -206,6 +206,45 @@ describe('Pure functions', () => {
       expect(Maybe.equalsValue('bar')(just)).toBeFalsy()
     })
   })
+
+  describe('lift', () => {
+    const find = <T>(predicate: (v: T) => boolean) => (list: T[]): T | void => {
+      const fn = ([item, ...list]: T[]): T | void => {
+        if (predicate(item) === true) { return item }
+        if (list.length === 0) { return undefined }
+        return fn(list)
+      }
+      return fn(list)
+    }
+    type DataItem = {
+      id: number,
+      name: string,
+    }
+    const data: DataItem[] = [{ id: 1, name: 'Jayson' }, { id: 2, name: 'Michael' }]
+    const predicateValue = ({ id }: DataItem) => id === 1
+    const predicateNull = ({ id }: DataItem) => id === 10
+
+    it('find (helper)', () => {
+      const finded = find(predicateValue)(data)
+      const notBeFound = find(predicateNull)(data)
+      expect(finded).toEqual(data[0])
+      expect(notBeFound).toBeUndefined()
+    })
+
+    it('with value and null to find', () => {
+      const finded = Maybe.lift(find(predicateValue), data)
+      const notFound = Maybe.lift(find(predicateNull), data)
+      expect(finded.toString()).toBe('Just([object Object])')
+      expect(notFound.toString()).toBe('Nothing()')
+    })
+
+    it('with value and null to find carried', () => {
+      const safeFind = Maybe.lift(find(predicateValue))
+      const safeFindNothing = Maybe.lift(find(predicateNull))
+      expect(safeFind(data).toString()).toBe('Just([object Object])')
+      expect(safeFindNothing(data).toString()).toBe('Nothing()')
+    })
+  })
 })
 
 describe('Just and Nothing', () => {

--- a/tests/maybe.test.ts
+++ b/tests/maybe.test.ts
@@ -66,9 +66,11 @@ describe('Pure functions', () => {
       const just = Maybe.of(234)
       const nothing = Maybe.of(null)
       const nothing2 = Maybe.of(undefined)
+      const chained1 = Maybe.chain(double, nothing)
+      const chained2 = Maybe.chain(double, nothing2)
       expect(Maybe.chain(toNothing, just)).toBeUndefined()
-      expect(Maybe.chain(double, nothing)).toBeUndefined()
-      expect(Maybe.chain(double, nothing2)).toBeUndefined()
+      expect(chained1  instanceof Maybe.Nothing).toBe(true)
+      expect(chained2  instanceof Maybe.Nothing).toBe(true)
     })
 
     it('carry', () => {
@@ -300,21 +302,21 @@ describe('Just and Nothing', () => {
     expect(just.toString()).toBe('Just(5)')
     expect(just.chain(double)).toBe(10)
     expect(just.map(double).chain(double)).toBe(20)
-    expect(just.map(double).map(double).chain(toNothing)).toBeUndefined()
+    expect(just.map(double).map(double).map(toNothing).chain(double) instanceof Maybe.Nothing).toBe(true)
     expect(
       just
         .map(double)
         .map(double)
         .map(toNothing)
-        .chain(double)
-    ).toBeUndefined()
+        .chain(double) instanceof Maybe.Nothing
+    ).toBe(true)
     expect(
       just
         .map(double)
         .map(double)
         .map(toNull)
-        .chain(double)
-    ).toBeUndefined()
+        .chain(double) instanceof Maybe.Nothing
+    ).toBe(true)
   })
 
   it('getOrElse', () => {

--- a/ts/doc.tsconfig.json
+++ b/ts/doc.tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../tsconfig.json",
   "include": ["../src"],
-  "exclude": ["../src/helpers.ts"],
   "compilerOptions": {
     "sourceMap": false,
     "sourceRoot": null


### PR DESCRIPTION
### :gift: Added
- `lift` as pure function for `Maybe`
- `Either` monad
- `Maybe` type for ts-doc annotation :tada:
- Alias for `Maybe` interface for use as type - `Shape`, this need using with context `Maybe.Shape<T>`

### :surfer: Changed
- Fixed mistake in naming `mather` to `matcher` :sweat_smile:
- Fixed type `ApplicativeResult` (it could not return the nullable, now this will be available)
- :fire: **WARNING** `MaybeShape` marked as **Deprecated**!
- :fire: `Maybe.chain` was fixed, now will returns `Nothing` if the method was called on `Nothing`!